### PR TITLE
Reexport CoveCrypt and Crypto Core

### DIFF
--- a/crates/cloudproof/Cargo.toml
+++ b/crates/cloudproof/Cargo.toml
@@ -22,6 +22,11 @@ wasm_bindgen = [
   "cloudproof_findex/wasm_bindgen",
   "cloudproof_fpe/wasm_bindgen",
 ]
+default = [
+  "cloudproof_cover_crypt/default",
+  "cloudproof_findex/default",
+  "cloudproof_fpe/default",
+]
 
 [dependencies]
 cloudproof_cover_crypt = { path = "../cover_crypt", optional = true }

--- a/crates/cloudproof/src/lib.rs
+++ b/crates/cloudproof/src/lib.rs
@@ -20,3 +20,11 @@ pub use cloudproof_fpe::ffi as fpe_ffi;
 pub use cloudproof_fpe::pyo3 as fpe_python;
 #[cfg(feature = "wasm_bindgen")]
 pub use cloudproof_fpe::wasm_bindgen as fpe_wasm_bindgen;
+
+// re-export of CoverCrypt and Crypto Core
+// so that projects that use their low level functionalities
+// do  not have to depend on them directly, avoiding version conflicts.
+#[cfg(feature = "default")]
+pub mod reexport {
+    pub use cloudproof_cover_crypt::reexport::{cover_crypt, crypto_core};
+}

--- a/crates/cover_crypt/Cargo.toml
+++ b/crates/cover_crypt/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
 name = "cloudproof_cover_crypt"
 version = "11.0.0"
-authors = [
-  "Théophile Brézot<theophile.brezot@cosmian.com>",
-]
+authors = ["Théophile Brézot<theophile.brezot@cosmian.com>"]
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Cosmian CoverCrypt Cloudproof library"
@@ -16,6 +14,7 @@ name = "cloudproof_cover_crypt"
 ffi = ["cosmian_ffi_utils", "lazy_static"]
 python = ["pyo3"]
 wasm_bindgen = ["js-sys", "wasm-bindgen"]
+default = []
 
 [dependencies]
 cosmian_cover_crypt = { version = "11.0.0", features = ["serialization"] }

--- a/crates/cover_crypt/src/lib.rs
+++ b/crates/cover_crypt/src/lib.rs
@@ -8,3 +8,12 @@ pub mod pyo3;
 
 #[cfg(feature = "wasm_bindgen")]
 pub mod wasm_bindgen;
+
+// re-export of CoverCrypt and Crypto Core
+// so that projects that use their low level functionalities
+// do  not have to depend on them directly, avoiding version conflicts.
+#[cfg(feature = "default")]
+pub mod reexport {
+    pub use cosmian_cover_crypt as cover_crypt;
+    pub use cosmian_crypto_core as crypto_core;
+}

--- a/crates/findex/Cargo.toml
+++ b/crates/findex/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
 name = "cloudproof_findex"
 version = "3.0.0"
-authors = [
-  "Théophile Brézot<theophile.brezot@cosmian.com>",
-]
+authors = ["Théophile Brézot<theophile.brezot@cosmian.com>"]
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Cosmian Findex Cloudproof library"
@@ -17,7 +15,14 @@ cloud = ["reqwest", "base64"]
 ffi = ["cosmian_ffi_utils", "base64", "serde_json", "tokio/rt-multi-thread"]
 python = ["cloud", "futures", "pyo3", "tokio/rt-multi-thread"]
 sqlite = ["base64", "faker_rand", "rand", "rusqlite", "serde", "serde_json"]
-wasm_bindgen = ["cloud", "js-sys", "hex", "wasm-bindgen", "wasm-bindgen-futures"]
+wasm_bindgen = [
+  "cloud",
+  "js-sys",
+  "hex",
+  "wasm-bindgen",
+  "wasm-bindgen-futures",
+]
+default = []
 
 [dependencies]
 cosmian_crypto_core.workspace = true
@@ -32,7 +37,9 @@ hex = { version = "0.4.3", optional = true }
 js-sys = { workspace = true, optional = true }
 pyo3 = { workspace = true, features = ["extension-module"], optional = true }
 rand = { version = "0.8", optional = true }
-reqwest = { version = "0.11.14", features = ["rustls-tls"], default-features = false, optional = true }
+reqwest = { version = "0.11.14", features = [
+  "rustls-tls",
+], default-features = false, optional = true }
 rusqlite = { version = "0.28", features = ["bundled"], optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0.93", optional = true }

--- a/crates/fpe/Cargo.toml
+++ b/crates/fpe/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
 name = "cloudproof_fpe"
 version = "0.1.0"
-authors = [
-  "Théophile Brézot<theophile.brezot@cosmian.com>",
-]
+authors = ["Théophile Brézot<theophile.brezot@cosmian.com>"]
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Cosmian Cloudproof FPE library"
@@ -20,6 +18,7 @@ name = "benches"
 ffi = ["cosmian_ffi_utils"]
 python = ["pyo3"]
 wasm_bindgen = ["js-sys", "wasm-bindgen"]
+default = []
 
 [dependencies]
 aes = { version = "0.8" }
@@ -37,7 +36,9 @@ wasm-bindgen = { workspace = true, optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.4.0", default-features = false }
-getrandom = { version = "0.2", features = ["js"] } # required by wasm-bindgen-test
+getrandom = { version = "0.2", features = [
+  "js",
+] } # required by wasm-bindgen-test
 rand = "0.8"
 rand_chacha = "0.3"
 rand_distr = "0.4"


### PR DESCRIPTION
Re-export of CoverCrypt and Crypto Core so that projects that use their low-level functionalities do not have to depend on them directly, avoiding version conflicts.

Made a `default` feature for crates so that Rust projects building from `cloudproof` can use that feature without importing other unnecessary features (such as wasm, pyo3, ffi, etc...)


example usage in projects after adding `cloudproof` as a dependency


```rust
use cloudproof::reexport::cover_crypt::abe_policy::AccessPolicy;

use cloudproof::reexport::crypto_core::{
    reexport::rand_core::{RngCore, SeedableRng},
    CsRng,
};
```