### PR TITLE
chore: make cloudproof crate publishable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ name: Cloudproof build
 on:
   push:
     tags:
-      - "*"
+      - '*'
   pull_request:
 
 jobs:
@@ -14,8 +14,8 @@ jobs:
       project-name: cloudproof_rust
       toolchain: nightly-2023-03-20
       kms-version: 4.3.3
-      branch-java: develop
-      branch-js: develop
-      branch-flutter: fix_errors
-      branch-python: upgrade_findex_for_ci
+      branch-java: v5.0.0
+      branch-js: v8.1.0
+      branch-flutter: v6.0.2
+      branch-python: cloudproof_rust_1.3.0
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,9 +52,12 @@ jobs:
           pushd crates/findex
           cargo publish --dry-run
           popd
-          # pushd crates/fpe
-          # cargo publish --dry-run
-          # popd
+          pushd crates/fpe
+          cargo publish --dry-run
+          popd
+          pushd crates/cloudproof
+          cargo publish --dry-run
+          popd
 
       - name: Verify semver integrity
         run: |
@@ -64,6 +67,9 @@ jobs:
           pushd crates/findex
           cargo semver-checks check-release
           popd
-          # pushd crates/fpe
-          # cargo semver-checks check-release
-          # popd
+          pushd crates/fpe
+          cargo semver-checks check-release
+          popd
+          pushd crates/cloudproof
+          cargo semver-checks check-release
+          popd

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.3.0] - 2023-04-26
+
+### Features
+
+- Make cloudproof crate publishable and publish it in CI on tags
+
 ## [1.2.0] - 2023-04-25
 
 ### Features

--- a/crates/cloudproof/Cargo.toml
+++ b/crates/cloudproof/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cloudproof"
-version = "1.2.0"
+version = "1.3.0"
 authors = ["Théophile Brézot<theophile.brezot@cosmian.com>"]
 edition = "2021"
 license = "MIT/Apache-2.0"
@@ -29,6 +29,6 @@ default = [
 ]
 
 [dependencies]
-cloudproof_cover_crypt = { path = "../cover_crypt", optional = true }
-cloudproof_findex = { path = "../findex", optional = true }
-cloudproof_fpe = { path = "../fpe", optional = true }
+cloudproof_cover_crypt = { version = "11.0.1", optional = true }
+cloudproof_findex = { version = "3.0.1", optional = true }
+cloudproof_fpe = { version = "0.1.0", optional = true }

--- a/crates/cover_crypt/Cargo.toml
+++ b/crates/cover_crypt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cloudproof_cover_crypt"
-version = "11.0.0"
+version = "11.0.1"
 authors = ["Théophile Brézot<theophile.brezot@cosmian.com>"]
 edition = "2021"
 license = "MIT/Apache-2.0"

--- a/crates/fpe/Cargo.toml
+++ b/crates/fpe/Cargo.toml
@@ -22,7 +22,7 @@ default = []
 
 [dependencies]
 aes = { version = "0.8" }
-fpe = { git = "https://github.com/Cosmian/cosmian_fpe" }
+cosmian_fpe = { version = "0.5.2" }
 itertools = { version = "0.10" }
 num-bigint = { version = "0.4", default-features = false }
 num-integer = { version = "0.1", default-features = false }

--- a/crates/fpe/src/core/alphabet.rs
+++ b/crates/fpe/src/core/alphabet.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, fmt::Display};
 
 use aes::Aes256;
-use fpe::ff1::{FF1h, FlexibleNumeralString};
+use cosmian_fpe::ff1::{FF1h, FlexibleNumeralString};
 use itertools::Itertools;
 
 use super::AnoError;


### PR DESCRIPTION
du to release 1.3.0 (without `improve ffi error` feature), need to merge main with develop manually this time