### PR TITLE
Add function to split encrypted header from ciphertext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.2.4] - 2023-09-19
+
+### Features
+
+- Add a way to split encrypted header and ciphertext from raw bytes
+
 ## [2.2.3] - 2023-09-19
 
 ### Bug Fixes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ resolver = "1"
 [workspace.dependencies]
 async-trait = "0.1.73"
 base64 = "0.21.4"
-cosmian_crypto_core = "9.2.0"
+cosmian_crypto_core = "9.2.1"
 cosmian_ffi_utils = "0.1.2"
 hex = "0.4.3"
 js-sys = "0.3"

--- a/crates/cloudproof/Cargo.toml
+++ b/crates/cloudproof/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cloudproof"
-version = "2.2.3"
+version = "2.2.4"
 authors = [
   "Théophile Brézot<theophile.brezot@cosmian.com>",
   "Emmanuel Coste<emmanuel.coste@cosmian.com>",

--- a/crates/cover_crypt/src/wasm_bindgen/hybrid_cc_aes.rs
+++ b/crates/cover_crypt/src/wasm_bindgen/hybrid_cc_aes.rs
@@ -368,7 +368,11 @@ pub fn webassembly_split_encrypted_header(
     Reflect::set(
         &obj,
         &JsValue::from_str("encryptedHeader"),
-        &Uint8Array::from(header.serialize().unwrap().to_vec().as_slice()),
+        &Uint8Array::from(
+            wasm_unwrap!(header.serialize(), "Cannot serialize encrypted header")
+                .to_vec()
+                .as_slice(),
+        ),
     )?;
     Reflect::set(
         &obj,

--- a/crates/cover_crypt/src/wasm_bindgen/hybrid_cc_aes.rs
+++ b/crates/cover_crypt/src/wasm_bindgen/hybrid_cc_aes.rs
@@ -343,9 +343,7 @@ pub fn webassembly_hybrid_decrypt(
 
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(
-        typescript_type = "Array<{ encryptedHeader: Uint8Array, ciphertext: Uint8Array }>"
-    )]
+    #[wasm_bindgen(typescript_type = "{ encryptedHeader: Uint8Array, ciphertext: Uint8Array }")]
     pub type EncryptedHeaderCiphertext;
 }
 


### PR DESCRIPTION
This PR adds a way, given raw bytes, to separate encrypted header from ciphertext, returning both of them into a struct compatible with `wasm_bindgen`, to be used from typescript