### PR TITLE
fix: ffi unwrap return code changed to -1 (instead of the reserved re…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,6 @@ jobs:
       branch-js: develop
       branch-kms-js: v2.0.0
       branch-flutter: develop
-      branch-python: develop
+      branch-python: findex/v6
       exclusions: --exclude=cloudproof_findex
     secrets: inherit

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,8 @@ resolver = "1"
 async-trait = "0.1.74"
 base64 = "0.21.5"
 cosmian_crypto_core = { version = "9.3.0", default-features = false }
-cosmian_ffi_utils = "0.1.2"
+# cosmian_ffi_utils = "0.1.2"
+cosmian_ffi_utils = { path = "crates/ffi_utils"}
 hex = "0.4.3"
 js-sys = "0.3"
 pyo3 = { version = "0.20.0", features = [

--- a/crates/aesgcm/Cargo.toml
+++ b/crates/aesgcm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cloudproof_aesgcm"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Emmanuel Coste<emmanuel.coste@cosmian.com>"]
 edition = "2021"
 license-file = "../../LICENSE.md"
@@ -8,7 +8,7 @@ repository = "https://github.com/cosmian/cloudproof_rust/"
 description = "Cosmian AES256GCM library"
 
 [lib]
-crate-type = ["cdylib", "rlib", "staticlib"]
+crate-type = ["cdylib", "lib", "staticlib"]
 name = "cloudproof_aesgcm"
 
 [features]

--- a/crates/anonymization/Cargo.toml
+++ b/crates/anonymization/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cloudproof_anonymization"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Hugo Rosenkranz-costa<hugo.rosenkranz@cosmian.com>"]
 edition = "2021"
 license-file = "../../LICENSE.md"
@@ -8,7 +8,7 @@ repository = "https://github.com/cosmian/cloudproof_rust/"
 description = "Cosmian Cloudproof Anonymization library"
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib", "lib", "staticlib"]
 name = "cloudproof_anonymization"
 
 [features]

--- a/crates/cloudproof/Cargo.toml
+++ b/crates/cloudproof/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cloudproof"
-version = "2.3.0"
+version = "2.4.0"
 authors = [
   "Théophile Brézot<theophile.brezot@cosmian.com>",
   "Emmanuel Coste<emmanuel.coste@cosmian.com>",
@@ -14,7 +14,7 @@ repository = "https://github.com/cosmian/cloudproof_rust/"
 description = "Cosmian Cloudproof library"
 
 [lib]
-crate-type = ["cdylib", "rlib", "staticlib"]
+crate-type = ["cdylib", "lib", "staticlib"]
 name = "cloudproof"
 
 [features]
@@ -50,9 +50,9 @@ cloudproof_fpe = { path = "../fpe", optional = true }
 #  - to publish `cloudproof` package, we must publish those sub-crates individually and manually.
 #  - cbindgen follows the cargo deps and fetch the crates from crates.io.
 ######
-#cloudproof_aesgcm = { version = "0.1.2", optional = true }
-#cloudproof_anonymization = { version = "0.1.1", optional = true }
-#cloudproof_cover_crypt = { version = "13.0.0", optional = true }
-#cloudproof_ecies = { version = "0.1.2", optional = true }
-#cloudproof_findex = { version = "5.0.4", optional = true }
-#cloudproof_fpe = { version = "0.2.1", optional = true }
+#cloudproof_aesgcm = { version = "0.1.3", optional = true }
+#cloudproof_anonymization = { version = "0.1.2", optional = true }
+#cloudproof_cover_crypt = { version = "13.0.1", optional = true }
+#cloudproof_ecies = { version = "0.1.3", optional = true }
+#cloudproof_findex = { version = "6.0.0", optional = true }
+#cloudproof_fpe = { version = "0.2.2", optional = true }

--- a/crates/cover_crypt/Cargo.toml
+++ b/crates/cover_crypt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cloudproof_cover_crypt"
-version = "13.0.0"
+version = "13.0.1"
 authors = ["Théophile Brézot<theophile.brezot@cosmian.com>"]
 edition = "2021"
 license-file = "../../LICENSE.md"
@@ -8,7 +8,7 @@ repository = "https://github.com/cosmian/cloudproof_rust/"
 description = "Cosmian Covercrypt Cloudproof library"
 
 [lib]
-crate-type = ["cdylib", "rlib", "staticlib"]
+crate-type = ["cdylib", "lib", "staticlib"]
 name = "cloudproof_cover_crypt"
 
 [features]

--- a/crates/ecies/Cargo.toml
+++ b/crates/ecies/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cloudproof_ecies"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Emmanuel Coste<emmanuel.coste@cosmian.com>"]
 edition = "2021"
 license-file = "../../LICENSE.md"
@@ -8,7 +8,7 @@ repository = "https://github.com/cosmian/cloudproof_rust/"
 description = "Cosmian ECIES scheme library"
 
 [lib]
-crate-type = ["cdylib", "rlib", "staticlib"]
+crate-type = ["cdylib", "lib", "staticlib"]
 name = "cloudproof_ecies"
 
 [features]

--- a/crates/ffi_utils/Cargo.toml
+++ b/crates/ffi_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmian_ffi_utils"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Théophile Brézot<theophile.brezot@cosmian.com>"]
 edition = "2021"
 license-file = "../../LICENSE.md"

--- a/crates/ffi_utils/src/macros.rs
+++ b/crates/ffi_utils/src/macros.rs
@@ -22,7 +22,7 @@ macro_rules! ffi_not_null {
 /// early with 1.
 ///
 /// - `res` : result to unwrap
-/// - `msg` : (optional) additional message to use as error
+/// - `msg` : additional message to use as error
 #[macro_export]
 macro_rules! ffi_unwrap {
     ($res:expr, $msg:expr) => {
@@ -33,7 +33,19 @@ macro_rules! ffi_unwrap {
                     "{}: {}",
                     $msg, e
                 )));
-                return 1_i32;
+                return -1_i32;
+            }
+        }
+    };
+    ($res:expr, $msg:expr, $code:expr) => {
+        match $res {
+            Ok(v) => v,
+            Err(e) => {
+                $crate::error::set_last_error($crate::error::FfiError::Generic(format!(
+                    "{}: {}",
+                    $msg, e
+                )));
+                return $code;
             }
         }
     };

--- a/crates/findex/Cargo.toml
+++ b/crates/findex/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/cosmian/cloudproof_rust/"
 description = "Cosmian Findex Cloudproof library"
 
 [lib]
-crate-type = ["cdylib", "rlib", "staticlib"]
+crate-type = ["cdylib", "lib", "staticlib"]
 name = "cloudproof_findex"
 
 [features]

--- a/crates/fpe/Cargo.toml
+++ b/crates/fpe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cloudproof_fpe"
-version = "0.2.1"
+version = "0.2.3"
 authors = ["Théophile Brézot<theophile.brezot@cosmian.com>"]
 edition = "2021"
 license-file = "../../LICENSE.md"
@@ -8,7 +8,7 @@ repository = "https://github.com/cosmian/cloudproof_rust/"
 description = "Cosmian Cloudproof FPE library"
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib", "lib", "staticlib"]
 name = "cloudproof_fpe"
 
 [[bench]]


### PR DESCRIPTION
…turn code 1)

- [x] prepare next release versions for all subcrates
- [x] make type of cargo lib  `crate-type = ["cdylib", "lib", "staticlib"]` to check semver before releasing
- [x] fix #55 
- [x] check new cloudproof_python branch with Findex v6 support