### PR TITLE
Feat/redis interface findex v7

### DIFF
--- a/crates/findex/.rustfmt.toml
+++ b/crates/findex/.rustfmt.toml
@@ -1,0 +1,43 @@
+# Specifies which edition is used by the parser.
+# Default value: "2015"
+edition = "2021"
+
+# How imports should be grouped into use statements. Imports will be merged or split to the configured level of granularity.
+# Default value: Preserve
+imports_granularity = "Crate"
+
+# Format the metavariable matching patterns in macros.
+# Default value: false
+format_macro_matchers = true
+
+# Format string literals where necessary
+# Default value: false
+format_strings = true
+
+# Reorder impl items. type and const are put first, then macros and methods.
+# Default value: false
+reorder_impl_items = true
+
+# Controls the strategy for how imports are grouped together.
+# Default value: Preserve
+group_imports = "StdExternalCrate"
+
+# Add trailing semicolon after break, continue and return
+# Default value: true
+trailing_semicolon = true
+
+# Enable unstable features on the unstable channel.
+# Default value: false
+unstable_features = true
+
+# Use field initialize shorthand if possible.
+# Default value: false
+use_field_init_shorthand = true
+
+# Break comments to fit on the line
+# Default value: false
+wrap_comments = true
+
+# Which version of the formatting rules to use. Version::One is backwards-compatible with Rustfmt 1.0. Other versions are only backwards compatible within a major version number.
+# Default value: "One"
+version = "Two"

--- a/crates/findex/.vscode/settings.json
+++ b/crates/findex/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
-    "rust-analyzer.cargo.features": [
-        "redis-interface"
-      ]
+  // change this to chgange the features
+  "rust-analyzer.cargo.features": [
+    "redis-interface"
+  ],
 }

--- a/crates/findex/.vscode/settings.json
+++ b/crates/findex/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   // change this to chgange the features
+  // "rest-interface"
   "rust-analyzer.cargo.features": [
     "redis-interface"
   ],

--- a/crates/findex/.vscode/settings.json
+++ b/crates/findex/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "rust-analyzer.cargo.features": [
+        "redis-interface"
+      ]
+}

--- a/crates/findex/.vscode/settings.json
+++ b/crates/findex/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-  // change this to chgange the features
+  // change this to change the features
   // "rest-interface"
   "rust-analyzer.cargo.features": [
     "redis-interface"

--- a/crates/findex/Cargo.toml
+++ b/crates/findex/Cargo.toml
@@ -67,6 +67,9 @@ rest-interface = [
 sqlite-interface = ["rusqlite"]
 
 [dependencies]
+findex = { git = "https://www.github.com/Cosmian/findex", branch = "test/cloudproof_v7", features = [
+  "test-utils",
+] }
 # Optional dependencies
 rand_chacha = { version = "0.3.1", optional = true }
 rand_core = { version = "0.6.4", optional = true }
@@ -76,20 +79,19 @@ base64 = { workspace = true, optional = true }
 cosmian_crypto_core = { workspace = true }
 cosmian_ffi_utils = { workspace = true, optional = true }
 cosmian_findex = "6.0.0"
-findex = { git = "https://www.github.com/Cosmian/findex", branch = "test/cloudproof_v7"}
 futures = { version = "0.3.30", optional = true }
 js-sys = { workspace = true, optional = true }
 lazy_static = { version = "1.4.0", optional = true }
 log = { version = "0.4.20", optional = true }
 pyo3 = { workspace = true, optional = true }
 rand = { workspace = true, optional = true }
-redis = { version="0.27.5", features = [
+redis = { version = "0.27.5", features = [
   "aio",
   "ahash",
   "script",
   "tokio-comp",
   "connection-manager",
-], optional = true}
+], optional = true }
 reqwest = { version = "0.11.24", default-features = false, optional = true }
 rusqlite = { version = "0.31.0", features = ["bundled"], optional = true }
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/findex/Cargo.toml
+++ b/crates/findex/Cargo.toml
@@ -55,45 +55,50 @@ wasm = [
   "serialization",
 ]
 
-redis-interface = ["redis"]
+redis-interface = ["rand_chacha",]
 rest-interface = [
   "base64",
   "cosmian_crypto_core/ser",
   "reqwest",
   "serialization",
+  "rand_chacha",
+  "rand_core",
 ]
 sqlite-interface = ["rusqlite"]
 
 [dependencies]
 # Optional dependencies
+rand_chacha = { version = "0.3.1", optional = true }
+rand_core = { version = "0.6.4", optional = true }
 actix-rt = { version = "2.9", optional = true }
 async-trait = { workspace = true }
 base64 = { workspace = true, optional = true }
 cosmian_crypto_core = { workspace = true }
 cosmian_ffi_utils = { workspace = true, optional = true }
 cosmian_findex = "6.0.0"
+findex = { git = "https://www.github.com/Cosmian/findex", branch = "eprint" }
 futures = { version = "0.3.30", optional = true }
 js-sys = { workspace = true, optional = true }
 lazy_static = { version = "1.4.0", optional = true }
 log = { version = "0.4.20", optional = true }
 pyo3 = { workspace = true, optional = true }
 rand = { workspace = true, optional = true }
-redis = { version = "0.23", features = [
+redis = { version="0.27.5", features = [
   "aio",
   "ahash",
   "script",
-  "connection-manager",
   "tokio-comp",
-], optional = true }
+  "connection-manager",
+]}
 reqwest = { version = "0.11.24", default-features = false, optional = true }
 rusqlite = { version = "0.31.0", features = ["bundled"], optional = true }
 serde = { version = "1.0", features = ["derive"] }
-tokio = { version = "1.36.0", optional = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 wasm-bindgen = { workspace = true, optional = true }
 wasm-bindgen-futures = { version = "0.4.41", optional = true }
 wasm-logger = { version = "0.2.0", optional = true }
+tokio = "1.41.0"
 
 [dev-dependencies]
 actix-rt = "2.9"

--- a/crates/findex/Cargo.toml
+++ b/crates/findex/Cargo.toml
@@ -55,7 +55,7 @@ wasm = [
   "serialization",
 ]
 
-redis-interface = ["rand_chacha",]
+redis-interface = ["rand_core", "rand_chacha", "redis"]
 rest-interface = [
   "base64",
   "cosmian_crypto_core/ser",
@@ -76,7 +76,7 @@ base64 = { workspace = true, optional = true }
 cosmian_crypto_core = { workspace = true }
 cosmian_ffi_utils = { workspace = true, optional = true }
 cosmian_findex = "6.0.0"
-findex = { git = "https://www.github.com/Cosmian/findex", branch = "eprint" }
+findex = { git = "https://www.github.com/Cosmian/findex", rev = "7f9ef11bb72b16cd64a436336d36db7e503d23ea"}
 futures = { version = "0.3.30", optional = true }
 js-sys = { workspace = true, optional = true }
 lazy_static = { version = "1.4.0", optional = true }
@@ -89,7 +89,7 @@ redis = { version="0.27.5", features = [
   "script",
   "tokio-comp",
   "connection-manager",
-]}
+], optional = true}
 reqwest = { version = "0.11.24", default-features = false, optional = true }
 rusqlite = { version = "0.31.0", features = ["bundled"], optional = true }
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/findex/Cargo.toml
+++ b/crates/findex/Cargo.toml
@@ -76,7 +76,7 @@ base64 = { workspace = true, optional = true }
 cosmian_crypto_core = { workspace = true }
 cosmian_ffi_utils = { workspace = true, optional = true }
 cosmian_findex = "6.0.0"
-findex = { git = "https://www.github.com/Cosmian/findex", rev = "7f9ef11bb72b16cd64a436336d36db7e503d23ea"}
+findex = { git = "https://www.github.com/Cosmian/findex", branch = "test/cloudproof_v7"}
 futures = { version = "0.3.30", optional = true }
 js-sys = { workspace = true, optional = true }
 lazy_static = { version = "1.4.0", optional = true }

--- a/crates/findex/src/db_interfaces/redis.rs
+++ b/crates/findex/src/db_interfaces/redis.rs
@@ -73,21 +73,6 @@ impl<Address: Hash + Eq, const WORD_LENGTH: usize> RedisBackend<Address, WORD_LE
             _marker_adr: PhantomData,
         })
     }
-    //  Script::new(GUARDED_WRITE_LUA_SCRIPT),
-
-    // TODO : manager is not compatible with the return types of memoryADT
-    // should we keep it ?
-    /// Connects to a Redis server with a `ConnectionManager`.
-    // pub async fn connect_with_manager(
-    //     manager: ConnectionManager,
-    // ) -> Result<Self, DbInterfaceError> {
-    //     Ok(Self {
-    //         connection: Arc::new(Mutex::new(manager)),
-    //         write_script: Script::new(GUARDED_WRITE_LUA_SCRIPT),
-    //         _marker_adr: PhantomData,
-    //         _marker_value: PhantomData,
-    //     })
-    // }
 
     pub fn clear_indexes(&self) -> Result<(), redis::RedisError> {
         let safe_connection = &mut *self.connection.lock().expect(POISONED_LOCK_ERROR_MSG);

--- a/crates/findex/src/db_interfaces/redis.rs
+++ b/crates/findex/src/db_interfaces/redis.rs
@@ -186,7 +186,6 @@ mod tests {
 
     #[actix_rt::test]
     #[serial]
-    #[ignore]
     async fn test_read_write() -> Result<(), DbInterfaceError> {
         // L'idée c'est de vérifier qu'une modification est rejetée si le gard n'est pas le bon.
 
@@ -237,6 +236,7 @@ mod tests {
     // TODO legacy test, à revoir
     #[actix_rt::test]
     #[serial]
+    #[ignore]
     async fn test_redis_backend() {
         log_init();
         trace!("Test Redis backend.");

--- a/crates/findex/src/db_interfaces/redis.rs
+++ b/crates/findex/src/db_interfaces/redis.rs
@@ -9,6 +9,7 @@ use std::{
 };
 
 use redis::{Commands, Connection, Script};
+use tracing::info;
 
 use crate::db_interfaces::DbInterfaceError;
 use findex::MemoryADT;
@@ -16,8 +17,7 @@ use findex::MemoryADT;
 #[derive(Clone)]
 pub struct RedisBackend<Address: Hash + Eq, const WORD_LENGTH: usize> {
     connection: Arc<Mutex<Connection>>,
-    // TODO : send script to redis and keep only the hash for invocations
-    write_script: Script,
+    write_script_hash: String,
     _marker_adr: PhantomData<Address>,
 }
 
@@ -30,8 +30,12 @@ const GUARDED_WRITE_LUA_SCRIPT: &str = r#"
 local guard_address = ARGV[1]
 local guard_value = ARGV[2]
 local length = ARGV[3]
+redis.log(redis.LOG_WARNING, "Guard Address: " .. tostring(guard_address))
+redis.log(redis.LOG_WARNING, "Guard Value: " .. tostring(guard_value))
+redis.log(redis.LOG_WARNING, "Length: " .. tostring(length))
 
 local value = redis.call('GET',ARGV[1])
+redis.log(redis.LOG_WARNING, "Current Value: " .. tostring(value))
 
 -- compare the value of the guard to the currently stored value
 if((value==false) or (not(value == false) and (guard_value == value))) then
@@ -58,20 +62,26 @@ impl<Address: Hash + Eq, const WORD_LENGTH: usize> Debug for RedisBackend<Addres
 impl<Address: Hash + Eq, const WORD_LENGTH: usize> RedisBackend<Address, WORD_LENGTH> {
     /// Connects to a Redis server using the given URL.
     pub async fn connect(url: &str) -> Result<Self, DbInterfaceError> {
-        Ok(Self {
-            connection: match redis::Client::open(url) {
-                Ok(client) => match client.get_connection() {
-                    Ok(con) => Arc::new(Mutex::new(con)),
-                    Err(e) => {
-                        panic!("Failed to connect to Redis: {}", e);
-                    }
-                },
-                Err(e) => panic!("Error creating redis client: {:?}", e),
+        let mut connection = match redis::Client::open(url) {
+            Ok(client) => match client.get_connection() {
+                Ok(con) => con,
+                Err(e) => {
+                    panic!("Failed to connect to Redis: {}", e);
+                }
             },
-            write_script: Script::new(GUARDED_WRITE_LUA_SCRIPT),
+            Err(e) => panic!("Error creating redis client: {:?}", e),
+        };
+        let write_script_hash = redis::cmd("SCRIPT")
+            .arg("LOAD")
+            .arg(GUARDED_WRITE_LUA_SCRIPT)
+            .query(&mut connection)?;
+        Ok(Self {
+            connection: Arc::new(Mutex::new(connection)),
+            write_script_hash,
             _marker_adr: PhantomData,
         })
     }
+    //  Script::new(GUARDED_WRITE_LUA_SCRIPT),
 
     // TODO : manager is not compatible with the return types of memoryADT
     // should we keep it ?
@@ -151,23 +161,21 @@ impl<
     ) -> Result<Option<Self::Word>, Self::Error> {
         let mut safe_connection = self.connection.lock().expect(POISONED_LOCK_ERROR_MSG);
         let (guard_address, guard_value) = guard;
-
-        let mut script_invocation = self.write_script.prepare_invoke();
-
-        script_invocation.arg(&*guard_address);
-        if let Some(byte_array) = guard_value {
-            script_invocation.arg(&byte_array);
+        println!("{:?}", self.write_script_hash.clone());
+        let mut cmd = redis::cmd("EVALSHA")
+            .arg(self.write_script_hash.clone())
+            .arg(0)
+            .arg(&*guard_address)
+            .clone(); // Why cloning is necessary : https://stackoverflow.com/questions/64728534/how-to-resolve-creates-a-temporary-variable-which-is-freed-while-still-in-use
+        cmd = if let Some(byte_array) = guard_value {
+            cmd.arg(&byte_array).arg(bindings.len()).clone()
         } else {
-            script_invocation.arg("false".to_string());
-        }
-        script_invocation.arg(bindings.len());
+            cmd.arg(888).arg(bindings.len()).clone()
+        };
         for (address, word) in bindings {
-            script_invocation.arg(&*address).arg(&word);
+            cmd = cmd.arg(&*address).arg(&word).clone();
         }
-
-        script_invocation
-            .invoke(&mut safe_connection)
-            .map_err(|e| e.into())
+        cmd.query(&mut safe_connection).map_err(|e| e.into())
     }
 }
 
@@ -184,18 +192,26 @@ mod tests {
 
     pub fn get_redis_url() -> String {
         if let Ok(var_env) = std::env::var("REDIS_HOST") {
-            format!("redis://{var_env}:6379")
+            // TODO revert 6379 server
+            format!("redis://{var_env}:9999")
         } else {
-            "redis://localhost:6379".to_string()
+            "redis://localhost:9999".to_string()
         }
+    }
+
+    const ADR_WORD_LENGTH: usize = 16;
+
+    async fn init_test_redis_db() -> RedisBackend<Address<ADR_WORD_LENGTH>, ADR_WORD_LENGTH> {
+        RedisBackend::<Address<ADR_WORD_LENGTH>, ADR_WORD_LENGTH>::connect(&get_redis_url())
+            .await
+            .unwrap()
     }
 
     #[actix_rt::test]
     #[serial]
     async fn test_db_flush() -> Result<(), DbInterfaceError> {
-        let memory = RedisBackend::<Address<16>, 16>::connect(&get_redis_url())
-            .await
-            .unwrap();
+        let memory = init_test_redis_db().await;
+
         let addr = Address::from([1; 16]);
         let word = [2; 16];
 
@@ -212,10 +228,58 @@ mod tests {
 
     #[actix_rt::test]
     #[serial]
+    #[ignore]
+    async fn checkforhash() -> Result<(), DbInterfaceError> {
+        let memory = init_test_redis_db().await;
+        todo!("test if the script's hash is still valid");
+        Ok(())
+    }
+
+    #[actix_rt::test]
+    #[serial]
+    #[ignore]
+    async fn asba() -> Result<(), DbInterfaceError> {
+        todo!("delete this after dev is finish");
+        let memory = init_test_redis_db().await;
+        let addr = Address::from([1; 16]);
+        let word = [2; 16];
+        memory.clear_indexes().unwrap();
+
+        let mut safe_connection = memory.connection.lock().expect(POISONED_LOCK_ERROR_MSG);
+
+        let asba: String = redis::cmd("SCRIPT")
+            .arg("LOAD")
+            .arg("redis.call('SET', ARGV[1], ARGV[2])")
+            .query(&mut safe_connection)?;
+        println!(
+            "èèèèèèèèè èèèè-------------------------------------------------- \n{:?} ------------------------- \n",
+            asba
+        );
+
+        let (guard_address, guard_value) = (addr.clone(), word);
+
+        let asba: () = redis::cmd("EVALSHA")
+            .arg(asba)
+            .arg(2)
+            .arg(&*guard_address)
+            .arg(&guard_value)
+            .query(&mut safe_connection)?;
+
+        println!(
+            "fdfdfdfdfdfdfdfdfdfdfd----------- \n{:?} ------------------------- \n",
+            asba
+        );
+        // .arg("false".to_string())
+        // .arg(1)
+        // .arg("TEST".to_string())
+        // .arg(888)
+        Ok(())
+    }
+
+    #[actix_rt::test]
+    #[serial]
     async fn test_rw_seq() -> Result<(), DbInterfaceError> {
-        let memory = RedisBackend::<Address<16>, 16>::connect(&get_redis_url())
-            .await
-            .unwrap();
+        let memory = init_test_redis_db().await;
         memory.clear_indexes().unwrap();
         block_on(test_single_write_and_read(&memory, rand::random()));
         Ok(())
@@ -224,9 +288,7 @@ mod tests {
     #[actix_rt::test]
     #[serial]
     async fn test_guard_seq() -> Result<(), DbInterfaceError> {
-        let memory = RedisBackend::<Address<16>, 16>::connect(&get_redis_url())
-            .await
-            .unwrap();
+        let memory = init_test_redis_db().await;
         memory.clear_indexes().unwrap();
         block_on(test_wrong_guard(&memory, rand::random()));
         Ok(())
@@ -235,9 +297,7 @@ mod tests {
     #[actix_rt::test]
     #[serial]
     async fn test_rw_ccr() -> Result<(), DbInterfaceError> {
-        let memory = RedisBackend::<Address<16>, 16>::connect(&get_redis_url())
-            .await
-            .unwrap();
+        let memory = init_test_redis_db().await;
         memory.clear_indexes().unwrap();
         block_on(test_guarded_write_concurrent(memory, rand::random()));
         Ok(())

--- a/crates/findex/src/db_interfaces/redis.rs
+++ b/crates/findex/src/db_interfaces/redis.rs
@@ -1,79 +1,30 @@
 //! Redis implementation of the Findex backends.
 
-use std::{collections::HashMap, sync::{Arc, Mutex}};
-
-use async_trait::async_trait;
-use cosmian_findex::{
-    CoreError as FindexCoreError, DbInterface, EncryptedValue, Token, TokenToEncryptedValueMap,
-    TokenWithEncryptedValueList, Tokens, ENTRY_LENGTH, LINK_LENGTH,
+use std::{
+    fmt::{self, Debug, Display},
+    hash::Hash,
+    marker::PhantomData,
+    sync::{Arc, Mutex},
 };
-use redis::{aio::ConnectionManager, pipe, AsyncCommands, Script, ConnectionManager};
-use tracing::trace;
+
+use redis::{Commands, Connection, Script, ToRedisArgs};
 
 use crate::db_interfaces::DbInterfaceError;
 use findex::MemoryADT;
 
-
-
-pub struct RedisBackend {
-    // TODO verify if those need to be in a mutex ?
-    connection: Arc<Mutex<ConnectionManager>>,
+#[derive(Clone)]
+pub struct RedisBackend<Address: Hash + Eq, const WORD_LENGTH: usize> {
+    connection: Arc<Mutex<Connection>>,
+    // TODO : send script to redis and keep only the hash for invocations
     write_script: Script,
+    _marker_adr: PhantomData<Address>,
 }
 
-impl std::fmt::Debug for RedisBackend {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("RedisBackend").finish()
-    }
-}
-
-impl RedisBackend {
-    /// Connects to a Redis server using the given URL.
-    pub async fn connect(url: &str) -> Result<Self, DbInterfaceError> {
-        let client = redis::Client::open(url)?;
-        let manager = ConnectionManager::new(client).await?;
-
-        Ok(Self {
-            manager,
-            upsert_script: Script::new(CONDITIONAL_UPSERT_SCRIPT),
-        })
-    }
-
-    /// Connects to a Redis server with a `ConnectionManager`.
-    pub async fn connect_with_manager(
-        manager: ConnectionManager,
-    ) -> Result<Self, DbInterfaceError> {
-        Ok(Self {
-            manager,
-            upsert_script: Script::new(CONDITIONAL_UPSERT_SCRIPT),
-        })
-    }
-
-    /// Clear all indexes
-    ///
-    /// # Warning
-    /// This is definitive
-    pub async fn clear_indexes(&self) -> Result<(), DbInterfaceError> {
-        redis::cmd("FLUSHDB")
-            .query_async(&mut self.manager.clone())
-            .await?;
-        Ok(())
-    }
-}
-
-
-/**
- * Atomically writes the bindings if the guard is still valid.
- * Returns the current value on the guard's address.
- * If the result is equal to the guard's old value, the bindings get
- * written.
- *
- * Args that are passed to the LUA script are, in order :
- * 1. Guard address.
- * 2. Guard value.
- * 3. Vector length.
- * 4+. Vector elements (address, word).
- */
+// Args that are passed to the LUA script are, in order:
+// 1. Guard address.
+// 2. Guard value.
+// 3. Vector length.
+// 4+. Vector elements (address, word).
 const GUARDED_WRITE_LUA_SCRIPT: &str = r#"
 local guard_address = ARGV[1]
 local guard_value = ARGV[2]
@@ -92,19 +43,135 @@ end
 return value
 "#;
 
+const POISONED_LOCK_ERROR_MSG: &str = "Poisoned lock error";
 
+impl<Address: Hash + Eq, const WORD_LENGTH: usize> Debug for RedisBackend<Address, WORD_LENGTH> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RedisMemory")
+            .field("connection", &"<redis::Connection>") // We don't want to debug the actual connection
+            .field("Addr type", &self._marker_adr)
+            .finish()
+    }
+}
 
+impl<Address: Hash + Eq, const WORD_LENGTH: usize> RedisBackend<Address, WORD_LENGTH> {
+    /// Connects to a Redis server using the given URL.
+    pub async fn connect(url: &str) -> Result<Self, DbInterfaceError> {
+        Ok(Self {
+            connection: match redis::Client::open(url) {
+                Ok(client) => match client.get_connection() {
+                    Ok(con) => Arc::new(Mutex::new(con)),
+                    Err(e) => {
+                        panic!("Failed to connect to Redis: {}", e);
+                    }
+                },
+                Err(e) => panic!("Error creating redis client: {:?}", e),
+            },
+            write_script: Script::new(GUARDED_WRITE_LUA_SCRIPT),
+            _marker_adr: PhantomData,
+        })
+    }
 
+    // TODO : manager is not compatible with the return types of memoryADT
+    // should we keep it ?
+    /// Connects to a Redis server with a `ConnectionManager`.
+    // pub async fn connect_with_manager(
+    //     manager: ConnectionManager,
+    // ) -> Result<Self, DbInterfaceError> {
+    //     Ok(Self {
+    //         connection: Arc::new(Mutex::new(manager)),
+    //         write_script: Script::new(GUARDED_WRITE_LUA_SCRIPT),
+    //         _marker_adr: PhantomData,
+    //         _marker_value: PhantomData,
+    //     })
+    // }
+
+    /// Clear all indexes
+    ///
+    /// # Warning
+    /// This is definitive
+    // pub async fn clear_indexes(&self) -> Result<(), DbInterfaceError> {
+    //     redis::cmd("FLUSHDB")
+    //         .query_async::<()>(&mut self.connection.lock().expect(POISONED_LOCK_ERROR_MSG) // explicitly setting <()> solves the following problem https://github.com/rust-lang/rust/issues/123748
+    //         .await?;
+    //     Ok(())
+    // }
+
+    pub fn clear_indexes(&self) -> Result<(), redis::RedisError> {
+        let safe_connection = &mut *self.connection.lock().expect(POISONED_LOCK_ERROR_MSG);
+        redis::cmd("FLUSHDB").exec(safe_connection)?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RedisMemoryError(String);
+
+impl std::error::Error for RedisMemoryError {}
+
+impl From<redis::RedisError> for RedisMemoryError {
+    fn from(err: redis::RedisError) -> Self {
+        Self(err.to_string())
+    }
+}
+
+impl Display for RedisMemoryError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Redis Memory Error: {}", self.0)
+    }
+}
+
+impl<Address: Send + Sync + Hash + Eq + Debug + Clone + ToRedisArgs, const WORD_LENGTH: usize>
+    MemoryADT for RedisBackend<Address, WORD_LENGTH>
+{
+    type Address = Address;
+    type Error = RedisMemoryError;
+    type Word = [u8; WORD_LENGTH];
+
+    async fn batch_read(
+        &self,
+        addresses: Vec<Address>,
+    ) -> Result<Vec<Option<Self::Word>>, Self::Error> {
+        let safe_connection = &mut *self.connection.lock().expect(POISONED_LOCK_ERROR_MSG);
+        let refs: Vec<&Address> = addresses.iter().collect::<Vec<&Address>>(); // Redis MGET requires references to the values
+        safe_connection
+            .mget::<_, Vec<_>>(&refs)
+            .map_err(Self::Error::from)
+    }
+
+    async fn guarded_write(
+        &self,
+        guard: (Self::Address, Option<Self::Word>),
+        bindings: Vec<(Self::Address, Self::Word)>,
+    ) -> Result<Option<Self::Word>, Self::Error> {
+        let mut safe_connection = self.connection.lock().expect(POISONED_LOCK_ERROR_MSG);
+        let (guard_address, guard_value) = guard;
+
+        let mut script_invocation = self.write_script.prepare_invoke();
+
+        script_invocation.arg(guard_address);
+        if let Some(byte_array) = guard_value {
+            script_invocation.arg(&byte_array);
+        } else {
+            script_invocation.arg("false".to_string());
+        }
+        script_invocation.arg(bindings.len());
+        for (address, word) in bindings {
+            script_invocation.arg(address).arg(&word);
+        }
+
+        script_invocation
+            .invoke(&mut safe_connection)
+            .map_err(|e| e.into())
+    }
+}
 
 #[cfg(test)]
 mod tests {
 
-    use std::collections::HashSet;
-
-    use cosmian_crypto_core::{CsRng, Nonce};
-    use cosmian_findex::{MAC_LENGTH, NONCE_LENGTH};
-    use rand::{RngCore, SeedableRng};
+    use futures::executor::block_on;
     use serial_test::serial;
+    use tracing::trace;
 
     use super::*;
     use crate::{db_interfaces::tests::test_backend, logger::log_init, Configuration};
@@ -119,108 +186,55 @@ mod tests {
 
     #[actix_rt::test]
     #[serial]
-    async fn test_upsert_conflict() -> Result<(), DbInterfaceError> {
-        log_init();
-        trace!("Test Redis upsert.");
+    #[ignore]
+    async fn test_read_write() -> Result<(), DbInterfaceError> {
+        // L'idée c'est de vérifier qu'une modification est rejetée si le gard n'est pas le bon.
 
-        let mut rng = CsRng::from_entropy();
+        let memory = RedisBackend::<u8, 1>::connect(&get_redis_url())
+            .await
+            .unwrap();
+        memory.clear_indexes().unwrap();
 
-        // Generate 333 random UIDs.
-        let mut uids = HashSet::with_capacity(333);
-        while uids.len() < 333 {
-            let mut uid = [0_u8; Token::LENGTH];
-            rng.fill_bytes(&mut uid);
-            uids.insert(uid);
-        }
-        let uids = uids.into_iter().collect::<Vec<_>>();
+        assert_eq!(
+            block_on(memory.guarded_write((0, None), vec![(6, [9])])).unwrap(),
+            None
+        );
 
-        let original_value = EncryptedValue {
-            nonce: Nonce::from([0; NONCE_LENGTH]),
-            ciphertext: [1; ENTRY_LENGTH],
-            tag: [0; MAC_LENGTH],
-        };
-        let changed_value = EncryptedValue {
-            nonce: Nonce::from([0; NONCE_LENGTH]),
-            ciphertext: [2; ENTRY_LENGTH],
-            tag: [0; MAC_LENGTH],
-        };
-        let new_value = EncryptedValue {
-            nonce: Nonce::from([0; NONCE_LENGTH]),
-            ciphertext: [2; ENTRY_LENGTH],
-            tag: [0; MAC_LENGTH],
-        };
+        assert_eq!(
+            block_on(memory.guarded_write((0, None), vec![(0, [2]), (1, [1]), (2, [1])])).unwrap(),
+            None
+        );
 
-        let url = get_redis_url();
-        let et = RedisEntryBackend::connect(&url).await?;
-        et.clear_indexes().await?;
+        assert_eq!(
+            block_on(memory.guarded_write((0, None), vec![(0, [4]), (3, [2]), (4, [2])])).unwrap(),
+            Some([2]) // should return Some([2]), indicating that the guard (None) failed
+        );
 
-        // First user upserts `original_value` to all the UIDs.
-        let rejected = et
-            .upsert(
-                HashMap::new().into(),
-                uids.iter()
-                    .map(|k| (Token::from(*k), original_value.clone()))
-                    .collect(),
-            )
-            .await?;
-        assert!(rejected.is_empty());
+        assert_eq!(
+            block_on(memory.guarded_write((0, Some([2])), vec![(0, [4]), (3, [3]), (4, [3])]))
+                .unwrap(),
+            Some([2])
+        );
 
-        let et_length = et.dump_tokens().await?.len();
-        trace!("Entry Table length: {et_length}");
-
-        // Another user upserts `changed_value` to 111 UIDs.
-        let rejected = et
-            .upsert(
-                uids.iter()
-                    .map(|k| (Token::from(*k), original_value.clone()))
-                    .collect(),
-                uids.iter()
-                    .enumerate()
-                    .map(|(idx, k)| {
-                        if idx % 3 == 0 {
-                            (Token::from(*k), changed_value.clone())
-                        } else {
-                            (Token::from(*k), original_value.clone())
-                        }
-                    })
-                    .collect(),
-            )
-            .await?;
-        assert!(rejected.is_empty());
-
-        let et_length = et.dump_tokens().await?.len();
-        println!("Entry Table length: {et_length}");
-
-        // The first user upserts `new_value` to all the UIDs from `original_value`. 111
-        // UIDs should conflict.
-        let rejected = et
-            .upsert(
-                uids.iter()
-                    .map(|k| (Token::from(*k), original_value.clone()))
-                    .collect(),
-                uids.iter()
-                    .map(|k| (Token::from(*k), new_value.clone()))
-                    .collect(),
-            )
-            .await?;
-        assert_eq!(111, rejected.len());
-        for prev_value in rejected.values() {
-            assert_eq!(prev_value, &changed_value);
-        }
-
-        // The firs user upserts `new_value` to the 111 rejected UIDs from
-        // `changed_value`.
-        let rejected = et
-            .upsert(
-                rejected.clone(),
-                rejected.keys().map(|k| (*k, new_value.clone())).collect(),
-            )
-            .await?;
-        assert_eq!(0, rejected.len());
-
+        assert_eq!(
+            vec![Some([1]), Some([1]), Some([3]), Some([3])],
+            block_on(memory.batch_read(vec![1, 2, 3, 4])).unwrap(),
+        );
         Ok(())
     }
 
+    #[actix_rt::test]
+    #[serial]
+    #[ignore]
+    async fn test_parallel() -> Result<(), DbInterfaceError> {
+        // spawner bcp d'acteurs qui frappent sur la db ensemble
+        // check this - branch epub
+        // Concurrently adding data to instances of the same vector should not introduce data loss.
+        //  pub async fn test_vector_concurrent<
+        Ok(())
+    }
+
+    // TODO legacy test, à revoir
     #[actix_rt::test]
     #[serial]
     async fn test_redis_backend() {
@@ -229,15 +243,12 @@ mod tests {
 
         let url = get_redis_url();
 
-        // Empty the Redis to prevent old ciphertexts to cause error during compacting.
-        let client = redis::Client::open(url.as_str()).unwrap();
-        let mut manager = ConnectionManager::new(client).await.unwrap();
-        redis::cmd("FLUSHDB")
-            .query_async::<_, ()>(&mut manager)
-            .await
-            .unwrap();
+        {
+            let memory_to_flush = RedisBackend::<u8, 1>::connect(url.as_str()).await.unwrap();
+            memory_to_flush.clear_indexes().unwrap();
+        }
 
-        let config = Configuration::Redis(url.clone(), url.clone());
+        let config: Configuration = Configuration::Redis(url.clone());
         test_backend(config).await;
     }
 }

--- a/crates/findex/src/db_interfaces/redis.rs
+++ b/crates/findex/src/db_interfaces/redis.rs
@@ -7,14 +7,14 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use redis::{aio::ConnectionManager, AsyncCommands, Commands, Script, ToRedisArgs};
+use redis::{Commands, Connection, Script, ToRedisArgs};
 
 use crate::db_interfaces::DbInterfaceError;
 use findex::MemoryADT;
 
 #[derive(Clone)]
 pub struct RedisBackend<Address: Hash + Eq, const WORD_LENGTH: usize> {
-    connection: ConnectionManager,
+    connection: Arc<Mutex<Connection>>,
     // TODO : send script to redis and keep only the hash for invocations
     write_script: Script,
     _marker_adr: PhantomData<Address>,
@@ -59,7 +59,12 @@ impl<Address: Hash + Eq, const WORD_LENGTH: usize> RedisBackend<Address, WORD_LE
     pub async fn connect(url: &str) -> Result<Self, DbInterfaceError> {
         Ok(Self {
             connection: match redis::Client::open(url) {
-                Ok(client) => Arc::new(Mutex::new(client.get_connection_manager().await?)),
+                Ok(client) => match client.get_connection() {
+                    Ok(con) => Arc::new(Mutex::new(con)),
+                    Err(e) => {
+                        panic!("Failed to connect to Redis: {}", e);
+                    }
+                },
                 Err(e) => panic!("Error creating redis client: {:?}", e),
             },
             write_script: Script::new(GUARDED_WRITE_LUA_SCRIPT),
@@ -70,24 +75,31 @@ impl<Address: Hash + Eq, const WORD_LENGTH: usize> RedisBackend<Address, WORD_LE
     // TODO : manager is not compatible with the return types of memoryADT
     // should we keep it ?
     /// Connects to a Redis server with a `ConnectionManager`.
-    pub async fn connect_with_manager(
-        manager: ConnectionManager,
-    ) -> Result<Self, DbInterfaceError> {
-        Ok(Self {
-            connection: Arc::new(Mutex::new(manager)),
-            write_script: Script::new(GUARDED_WRITE_LUA_SCRIPT),
-            _marker_adr: PhantomData,
-        })
-    }
+    // pub async fn connect_with_manager(
+    //     manager: ConnectionManager,
+    // ) -> Result<Self, DbInterfaceError> {
+    //     Ok(Self {
+    //         connection: Arc::new(Mutex::new(manager)),
+    //         write_script: Script::new(GUARDED_WRITE_LUA_SCRIPT),
+    //         _marker_adr: PhantomData,
+    //         _marker_value: PhantomData,
+    //     })
+    // }
 
     /// Clear all indexes
     ///
     /// # Warning
     /// This is definitive
-    pub async fn clear_indexes(&self) -> Result<(), DbInterfaceError> {
-        redis::cmd("FLUSHDB")
-            .query_async::<()>(&mut *self.connection.lock().expect(POISONED_LOCK_ERROR_MSG)) // explicitly setting <()> solves the following problem https://github.com/rust-lang/rust/issues/123748
-            .await?;
+    // pub async fn clear_indexes(&self) -> Result<(), DbInterfaceError> {
+    //     redis::cmd("FLUSHDB")
+    //         .query_async::<()>(&mut self.connection.lock().expect(POISONED_LOCK_ERROR_MSG) // explicitly setting <()> solves the following problem https://github.com/rust-lang/rust/issues/123748
+    //         .await?;
+    //     Ok(())
+    // }
+
+    pub fn clear_indexes(&self) -> Result<(), redis::RedisError> {
+        let safe_connection = &mut *self.connection.lock().expect(POISONED_LOCK_ERROR_MSG);
+        redis::cmd("FLUSHDB").exec(safe_connection)?;
         Ok(())
     }
 }
@@ -120,16 +132,12 @@ impl<Address: Send + Sync + Hash + Eq + Debug + Clone + ToRedisArgs, const WORD_
         &self,
         addresses: Vec<Address>,
     ) -> Result<Vec<Option<Self::Word>>, Self::Error> {
-        // let safe_connection = self.connection.lock().expect(POISONED_LOCK_ERROR_MSG);
-        // let mut lol = safe_connection.clone();
-        // std::mem::drop(safe_connection);
-        let refs: Vec<&Address> = addresses.iter().collect();
-        let value = self.clone().connection.mget::<_, Vec<_>>(&refs).await?;
-        Ok(value)
-        // safe_connection.mget(key)
+        let safe_connection = &mut *self.connection.lock().expect(POISONED_LOCK_ERROR_MSG);
+        let refs: Vec<&Address> = addresses.iter().collect::<Vec<&Address>>(); // Redis MGET requires references to the values
+        safe_connection
+            .mget::<_, Vec<_>>(&refs)
+            .map_err(Self::Error::from)
     }
-
-    // client.get_multiplexed_async_connection()
 
     async fn guarded_write(
         &self,

--- a/crates/findex/src/db_interfaces/redis.rs
+++ b/crates/findex/src/db_interfaces/redis.rs
@@ -1,58 +1,33 @@
 //! Redis implementation of the Findex backends.
 
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::{Arc, Mutex}};
 
 use async_trait::async_trait;
 use cosmian_findex::{
     CoreError as FindexCoreError, DbInterface, EncryptedValue, Token, TokenToEncryptedValueMap,
     TokenWithEncryptedValueList, Tokens, ENTRY_LENGTH, LINK_LENGTH,
 };
-use redis::{aio::ConnectionManager, pipe, AsyncCommands, Script};
+use redis::{aio::ConnectionManager, pipe, AsyncCommands, Script, ConnectionManager};
 use tracing::trace;
 
 use crate::db_interfaces::DbInterfaceError;
+use findex::MemoryADT;
 
-/// The length of the prefix of the table name in bytes
-/// 0x00ee for the entry table
-/// 0x00ef for the chain table
-const TABLE_PREFIX_LENGTH: usize = 2;
 
-#[derive(Copy, Clone)]
-enum FindexTable {
-    Entry = 0xee,
-    Chain = 0xef,
+
+pub struct RedisBackend {
+    // TODO verify if those need to be in a mutex ?
+    connection: Arc<Mutex<ConnectionManager>>,
+    write_script: Script,
 }
 
-/// Generate a key for the entry table or chain table
-fn build_key(table: FindexTable, uid: &[u8]) -> Vec<u8> {
-    [&[0x00, table as u8], uid].concat()
-}
-
-pub struct RedisEntryBackend {
-    manager: ConnectionManager,
-    upsert_script: Script,
-}
-
-impl std::fmt::Debug for RedisEntryBackend {
+impl std::fmt::Debug for RedisBackend {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("RedisEntryBackend").finish()
+        f.debug_struct("RedisBackend").finish()
     }
 }
 
-/// The conditional upsert script used to only update a table if the
-/// indexed value matches ARGV[2]. When the value does not match, the
-/// indexed value is returned.
-const CONDITIONAL_UPSERT_SCRIPT: &str = r"
-        local value=redis.call('GET',ARGV[1])
-        if((value==false) or (not(value == false) and (ARGV[2] == value))) then
-            redis.call('SET', ARGV[1], ARGV[3])
-            return
-        else
-            return value
-        end;
-    ";
-
-impl RedisEntryBackend {
+impl RedisBackend {
     /// Connects to a Redis server using the given URL.
     pub async fn connect(url: &str) -> Result<Self, DbInterfaceError> {
         let client = redis::Client::open(url)?;
@@ -86,234 +61,40 @@ impl RedisEntryBackend {
     }
 }
 
-#[async_trait(?Send)]
-impl DbInterface<ENTRY_LENGTH> for RedisEntryBackend {
-    type Error = DbInterfaceError;
 
-    async fn dump_tokens(&self) -> Result<Tokens, Self::Error> {
-        let keys: Vec<Vec<u8>> = self
-            .manager
-            .clone()
-            .keys(build_key(FindexTable::Entry, b"*"))
-            .await?;
+/**
+ * Atomically writes the bindings if the guard is still valid.
+ * Returns the current value on the guard's address.
+ * If the result is equal to the guard's old value, the bindings get
+ * written.
+ *
+ * Args that are passed to the LUA script are, in order :
+ * 1. Guard address.
+ * 2. Guard value.
+ * 3. Vector length.
+ * 4+. Vector elements (address, word).
+ */
+const GUARDED_WRITE_LUA_SCRIPT: &str = r#"
+local guard_address = ARGV[1]
+local guard_value = ARGV[2]
+local length = ARGV[3]
 
-        trace!("dumping {} keywords (ET+CT)", keys.len());
+local value = redis.call('GET',ARGV[1])
 
-        keys.iter()
-            .filter_map(|v| {
-                if v[..TABLE_PREFIX_LENGTH] == [0x00, FindexTable::Entry as u8] {
-                    Some(Token::try_from(&v[TABLE_PREFIX_LENGTH..]).map_err(Self::Error::Findex))
-                } else {
-                    None
-                }
-            })
-            .collect()
-    }
+-- compare the value of the guard to the currently stored value
+if((value==false) or (not(value == false) and (guard_value == value))) then
+    -- guard passed, loop over bindings and insert them
+    for i = 4,(length*2)+3,2
+    do
+        redis.call('SET', ARGV[i], ARGV[i+1])
+    end
+end
+return value
+"#;
 
-    async fn fetch(
-        &self,
-        tokens: Tokens,
-    ) -> Result<TokenWithEncryptedValueList<ENTRY_LENGTH>, Self::Error> {
-        trace!("fetch_entry_table num keywords: {}:", tokens.len());
 
-        if tokens.is_empty() {
-            return Ok(Default::default());
-        }
 
-        // Collect into a vector to fix the order.
-        let uids = tokens.into_iter().collect::<Vec<_>>();
 
-        let redis_keys = uids
-            .iter()
-            .map(|uid| build_key(FindexTable::Entry, uid))
-            .collect::<Vec<_>>();
-
-        let values: Vec<Vec<u8>> = self.manager.clone().mget(redis_keys).await?;
-
-        // Zip and filter empty values out.
-        let res = uids
-            .into_iter()
-            .zip(values)
-            .filter_map(|(k, v)| {
-                if v.is_empty() {
-                    None
-                } else {
-                    Some(EncryptedValue::try_from(v.as_slice()).map(|v| (k, v)))
-                }
-            })
-            .collect::<Result<Vec<_>, FindexCoreError>>()?;
-
-        trace!("fetch_entry_table non empty tuples len: {}", res.len());
-
-        Ok(res.into())
-    }
-
-    async fn upsert(
-        &self,
-        old_values: TokenToEncryptedValueMap<ENTRY_LENGTH>,
-        new_values: TokenToEncryptedValueMap<ENTRY_LENGTH>,
-    ) -> Result<TokenToEncryptedValueMap<ENTRY_LENGTH>, Self::Error> {
-        trace!("upsert_entry_table num keywords {:?}", new_values.len());
-
-        let mut rejected = HashMap::with_capacity(new_values.len());
-        for (uid, new_value) in new_values {
-            let new_value = Vec::from(&new_value);
-            let old_value = old_values.get(&uid).map(Vec::from).unwrap_or_default();
-            let key = build_key(FindexTable::Entry, &uid);
-
-            let indexed_value: Vec<_> = self
-                .upsert_script
-                .arg(key)
-                .arg(old_value)
-                .arg(new_value)
-                .invoke_async(&mut self.manager.clone())
-                .await?;
-
-            if !indexed_value.is_empty() {
-                let encrypted_value = EncryptedValue::try_from(indexed_value.as_slice())?;
-                rejected.insert(uid, encrypted_value);
-            }
-        }
-
-        trace!("upsert_entry_table rejected: {}", rejected.len());
-
-        Ok(rejected.into())
-    }
-
-    async fn insert(
-        &self,
-        items: TokenToEncryptedValueMap<ENTRY_LENGTH>,
-    ) -> Result<(), Self::Error> {
-        let mut pipe = pipe();
-        for (token, value) in &*items {
-            pipe.set(build_key(FindexTable::Entry, token), Vec::from(value));
-        }
-        pipe.atomic()
-            .query_async(&mut self.manager.clone())
-            .await
-            .map_err(Self::Error::from)
-    }
-
-    async fn delete(&self, entry_uids: Tokens) -> Result<(), Self::Error> {
-        let mut pipeline = pipe();
-        for uid in entry_uids {
-            pipeline.del(build_key(FindexTable::Entry, &uid));
-        }
-        pipeline
-            .atomic()
-            .query_async(&mut self.manager.clone())
-            .await
-            .map_err(Self::Error::from)
-    }
-}
-
-pub struct RedisChainBackend(ConnectionManager);
-
-impl std::fmt::Debug for RedisChainBackend {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("RedisChainBackend").finish()
-    }
-}
-
-impl RedisChainBackend {
-    /// Connects to a Redis server using the given `url`.
-    pub async fn connect(url: &str) -> Result<Self, DbInterfaceError> {
-        let client = redis::Client::open(url)?;
-        let manager = ConnectionManager::new(client).await?;
-        Ok(Self(manager))
-    }
-
-    /// Connects to a Redis server with a `ConnectionManager`.
-    pub async fn connect_with_manager(
-        manager: ConnectionManager,
-    ) -> Result<Self, DbInterfaceError> {
-        Ok(Self(manager))
-    }
-
-    /// Clear all indexes
-    ///
-    /// # Warning
-    /// This is definitive
-    pub async fn clear_indexes(&self) -> Result<(), DbInterfaceError> {
-        redis::cmd("FLUSHDB")
-            .query_async(&mut self.0.clone())
-            .await?;
-        Ok(())
-    }
-}
-
-#[async_trait(?Send)]
-impl DbInterface<LINK_LENGTH> for RedisChainBackend {
-    type Error = DbInterfaceError;
-
-    async fn dump_tokens(&self) -> Result<Tokens, Self::Error> {
-        panic!("No token dump is performed for the Chain Table.")
-    }
-
-    async fn fetch(
-        &self,
-        tokens: Tokens,
-    ) -> Result<TokenWithEncryptedValueList<LINK_LENGTH>, Self::Error> {
-        trace!("fetch_entry_table num keywords: {}:", tokens.len());
-        if tokens.is_empty() {
-            return Ok(Default::default());
-        }
-
-        let uids = tokens.into_iter().collect::<Vec<_>>();
-        let redis_keys = uids
-            .iter()
-            .map(|uid| build_key(FindexTable::Chain, uid))
-            .collect::<Vec<_>>();
-
-        let values: Vec<Vec<u8>> = self.0.clone().mget(redis_keys).await?;
-
-        // Zip and filter empty values out.
-        let res = uids
-            .into_iter()
-            .zip(values)
-            .filter(|(_, v)| !v.is_empty())
-            .map(|(k, v)| Ok((k, EncryptedValue::try_from(v.as_slice())?)))
-            .collect::<Result<Vec<_>, Self::Error>>()?;
-
-        trace!("fetch_entry_table non empty tuples len: {}", res.len());
-
-        Ok(res.into())
-    }
-
-    async fn upsert(
-        &self,
-        _old_values: TokenToEncryptedValueMap<LINK_LENGTH>,
-        _new_values: TokenToEncryptedValueMap<LINK_LENGTH>,
-    ) -> Result<TokenToEncryptedValueMap<LINK_LENGTH>, Self::Error> {
-        panic!("No token upsert is performed for the Chain Table.")
-    }
-
-    async fn insert(
-        &self,
-        items: TokenToEncryptedValueMap<LINK_LENGTH>,
-    ) -> Result<(), Self::Error> {
-        let mut pipe = pipe();
-        for (k, v) in &*items {
-            pipe.set(build_key(FindexTable::Chain, k), Vec::from(v));
-        }
-        pipe.atomic()
-            .query_async(&mut self.0.clone())
-            .await
-            .map_err(Self::Error::from)
-    }
-
-    async fn delete(&self, chain_uids: Tokens) -> Result<(), Self::Error> {
-        let mut pipeline = pipe();
-        for uid in chain_uids {
-            pipeline.del(build_key(FindexTable::Chain, &uid));
-        }
-        pipeline
-            .atomic()
-            .query_async(&mut self.0.clone())
-            .await
-            .map_err(Self::Error::from)
-    }
-}
 
 #[cfg(test)]
 mod tests {

--- a/crates/findex/src/db_interfaces/redis.rs
+++ b/crates/findex/src/db_interfaces/redis.rs
@@ -7,14 +7,14 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use redis::{Commands, Connection, Script, ToRedisArgs};
+use redis::{aio::ConnectionManager, AsyncCommands, Commands, Script, ToRedisArgs};
 
 use crate::db_interfaces::DbInterfaceError;
 use findex::MemoryADT;
 
 #[derive(Clone)]
 pub struct RedisBackend<Address: Hash + Eq, const WORD_LENGTH: usize> {
-    connection: Arc<Mutex<Connection>>,
+    connection: ConnectionManager,
     // TODO : send script to redis and keep only the hash for invocations
     write_script: Script,
     _marker_adr: PhantomData<Address>,
@@ -59,12 +59,7 @@ impl<Address: Hash + Eq, const WORD_LENGTH: usize> RedisBackend<Address, WORD_LE
     pub async fn connect(url: &str) -> Result<Self, DbInterfaceError> {
         Ok(Self {
             connection: match redis::Client::open(url) {
-                Ok(client) => match client.get_connection() {
-                    Ok(con) => Arc::new(Mutex::new(con)),
-                    Err(e) => {
-                        panic!("Failed to connect to Redis: {}", e);
-                    }
-                },
+                Ok(client) => Arc::new(Mutex::new(client.get_connection_manager().await?)),
                 Err(e) => panic!("Error creating redis client: {:?}", e),
             },
             write_script: Script::new(GUARDED_WRITE_LUA_SCRIPT),
@@ -75,31 +70,24 @@ impl<Address: Hash + Eq, const WORD_LENGTH: usize> RedisBackend<Address, WORD_LE
     // TODO : manager is not compatible with the return types of memoryADT
     // should we keep it ?
     /// Connects to a Redis server with a `ConnectionManager`.
-    // pub async fn connect_with_manager(
-    //     manager: ConnectionManager,
-    // ) -> Result<Self, DbInterfaceError> {
-    //     Ok(Self {
-    //         connection: Arc::new(Mutex::new(manager)),
-    //         write_script: Script::new(GUARDED_WRITE_LUA_SCRIPT),
-    //         _marker_adr: PhantomData,
-    //         _marker_value: PhantomData,
-    //     })
-    // }
+    pub async fn connect_with_manager(
+        manager: ConnectionManager,
+    ) -> Result<Self, DbInterfaceError> {
+        Ok(Self {
+            connection: Arc::new(Mutex::new(manager)),
+            write_script: Script::new(GUARDED_WRITE_LUA_SCRIPT),
+            _marker_adr: PhantomData,
+        })
+    }
 
     /// Clear all indexes
     ///
     /// # Warning
     /// This is definitive
-    // pub async fn clear_indexes(&self) -> Result<(), DbInterfaceError> {
-    //     redis::cmd("FLUSHDB")
-    //         .query_async::<()>(&mut self.connection.lock().expect(POISONED_LOCK_ERROR_MSG) // explicitly setting <()> solves the following problem https://github.com/rust-lang/rust/issues/123748
-    //         .await?;
-    //     Ok(())
-    // }
-
-    pub fn clear_indexes(&self) -> Result<(), redis::RedisError> {
-        let safe_connection = &mut *self.connection.lock().expect(POISONED_LOCK_ERROR_MSG);
-        redis::cmd("FLUSHDB").exec(safe_connection)?;
+    pub async fn clear_indexes(&self) -> Result<(), DbInterfaceError> {
+        redis::cmd("FLUSHDB")
+            .query_async::<()>(&mut *self.connection.lock().expect(POISONED_LOCK_ERROR_MSG)) // explicitly setting <()> solves the following problem https://github.com/rust-lang/rust/issues/123748
+            .await?;
         Ok(())
     }
 }
@@ -132,12 +120,16 @@ impl<Address: Send + Sync + Hash + Eq + Debug + Clone + ToRedisArgs, const WORD_
         &self,
         addresses: Vec<Address>,
     ) -> Result<Vec<Option<Self::Word>>, Self::Error> {
-        let safe_connection = &mut *self.connection.lock().expect(POISONED_LOCK_ERROR_MSG);
-        let refs: Vec<&Address> = addresses.iter().collect::<Vec<&Address>>(); // Redis MGET requires references to the values
-        safe_connection
-            .mget::<_, Vec<_>>(&refs)
-            .map_err(Self::Error::from)
+        // let safe_connection = self.connection.lock().expect(POISONED_LOCK_ERROR_MSG);
+        // let mut lol = safe_connection.clone();
+        // std::mem::drop(safe_connection);
+        let refs: Vec<&Address> = addresses.iter().collect();
+        let value = self.clone().connection.mget::<_, Vec<_>>(&refs).await?;
+        Ok(value)
+        // safe_connection.mget(key)
     }
+
+    // client.get_multiplexed_async_connection()
 
     async fn guarded_write(
         &self,

--- a/crates/findex/src/db_interfaces/redis.rs
+++ b/crates/findex/src/db_interfaces/redis.rs
@@ -1,5 +1,7 @@
 //! Redis implementation of the Findex backends.
-
+use crate::db_interfaces::DbInterfaceError;
+use findex::MemoryADT;
+use redis::{Commands, Connection};
 use std::{
     fmt::{self, Debug, Display},
     hash::Hash,
@@ -7,12 +9,6 @@ use std::{
     ops::Deref,
     sync::{Arc, Mutex},
 };
-
-use redis::{Commands, Connection, Script};
-use tracing::info;
-
-use crate::db_interfaces::DbInterfaceError;
-use findex::MemoryADT;
 
 #[derive(Clone)]
 pub struct RedisBackend<Address: Hash + Eq, const WORD_LENGTH: usize> {
@@ -30,12 +26,8 @@ const GUARDED_WRITE_LUA_SCRIPT: &str = r#"
 local guard_address = ARGV[1]
 local guard_value = ARGV[2]
 local length = ARGV[3]
-redis.log(redis.LOG_WARNING, "Guard Address: " .. tostring(guard_address))
-redis.log(redis.LOG_WARNING, "Guard Value: " .. tostring(guard_value))
-redis.log(redis.LOG_WARNING, "Length: " .. tostring(length))
 
 local value = redis.call('GET',ARGV[1])
-redis.log(redis.LOG_WARNING, "Current Value: " .. tostring(value))
 
 -- compare the value of the guard to the currently stored value
 if((value==false) or (not(value == false) and (guard_value == value))) then
@@ -97,17 +89,6 @@ impl<Address: Hash + Eq, const WORD_LENGTH: usize> RedisBackend<Address, WORD_LE
     //     })
     // }
 
-    /// Clear all indexes
-    ///
-    /// # Warning
-    /// This is definitive
-    // pub async fn clear_indexes(&self) -> Result<(), DbInterfaceError> {
-    //     redis::cmd("FLUSHDB")
-    //         .query_async::<()>(&mut self.connection.lock().expect(POISONED_LOCK_ERROR_MSG) // explicitly setting <()> solves the following problem https://github.com/rust-lang/rust/issues/123748
-    //         .await?;
-    //     Ok(())
-    // }
-
     pub fn clear_indexes(&self) -> Result<(), redis::RedisError> {
         let safe_connection = &mut *self.connection.lock().expect(POISONED_LOCK_ERROR_MSG);
         redis::cmd("FLUSHDB").exec(safe_connection)?;
@@ -161,7 +142,6 @@ impl<
     ) -> Result<Option<Self::Word>, Self::Error> {
         let mut safe_connection = self.connection.lock().expect(POISONED_LOCK_ERROR_MSG);
         let (guard_address, guard_value) = guard;
-        println!("{:?}", self.write_script_hash.clone());
         let mut cmd = redis::cmd("EVALSHA")
             .arg(self.write_script_hash.clone())
             .arg(0)
@@ -170,7 +150,7 @@ impl<
         cmd = if let Some(byte_array) = guard_value {
             cmd.arg(&byte_array).arg(bindings.len()).clone()
         } else {
-            cmd.arg(888).arg(bindings.len()).clone()
+            cmd.arg("false".to_string()).arg(bindings.len()).clone()
         };
         for (address, word) in bindings {
             cmd = cmd.arg(&*address).arg(&word).clone();
@@ -192,19 +172,21 @@ mod tests {
 
     pub fn get_redis_url() -> String {
         if let Ok(var_env) = std::env::var("REDIS_HOST") {
-            // TODO revert 6379 server
-            format!("redis://{var_env}:9999")
+            format!("redis://{var_env}:6379")
         } else {
-            "redis://localhost:9999".to_string()
+            "redis://localhost:6379".to_string()
         }
     }
 
-    const ADR_WORD_LENGTH: usize = 16;
+    const TEST_ADR_WORD_LENGTH: usize = 16;
 
-    async fn init_test_redis_db() -> RedisBackend<Address<ADR_WORD_LENGTH>, ADR_WORD_LENGTH> {
-        RedisBackend::<Address<ADR_WORD_LENGTH>, ADR_WORD_LENGTH>::connect(&get_redis_url())
-            .await
-            .unwrap()
+    async fn init_test_redis_db(
+    ) -> RedisBackend<Address<TEST_ADR_WORD_LENGTH>, TEST_ADR_WORD_LENGTH> {
+        RedisBackend::<Address<TEST_ADR_WORD_LENGTH>, TEST_ADR_WORD_LENGTH>::connect(
+            &get_redis_url(),
+        )
+        .await
+        .unwrap()
     }
 
     #[actix_rt::test]
@@ -223,56 +205,6 @@ mod tests {
 
         let result = block_on(memory.batch_read(vec![addr])).unwrap();
         assert_eq!(result, vec![None]);
-        Ok(())
-    }
-
-    #[actix_rt::test]
-    #[serial]
-    #[ignore]
-    async fn checkforhash() -> Result<(), DbInterfaceError> {
-        let memory = init_test_redis_db().await;
-        todo!("test if the script's hash is still valid");
-        Ok(())
-    }
-
-    #[actix_rt::test]
-    #[serial]
-    #[ignore]
-    async fn asba() -> Result<(), DbInterfaceError> {
-        todo!("delete this after dev is finish");
-        let memory = init_test_redis_db().await;
-        let addr = Address::from([1; 16]);
-        let word = [2; 16];
-        memory.clear_indexes().unwrap();
-
-        let mut safe_connection = memory.connection.lock().expect(POISONED_LOCK_ERROR_MSG);
-
-        let asba: String = redis::cmd("SCRIPT")
-            .arg("LOAD")
-            .arg("redis.call('SET', ARGV[1], ARGV[2])")
-            .query(&mut safe_connection)?;
-        println!(
-            "èèèèèèèèè èèèè-------------------------------------------------- \n{:?} ------------------------- \n",
-            asba
-        );
-
-        let (guard_address, guard_value) = (addr.clone(), word);
-
-        let asba: () = redis::cmd("EVALSHA")
-            .arg(asba)
-            .arg(2)
-            .arg(&*guard_address)
-            .arg(&guard_value)
-            .query(&mut safe_connection)?;
-
-        println!(
-            "fdfdfdfdfdfdfdfdfdfdfd----------- \n{:?} ------------------------- \n",
-            asba
-        );
-        // .arg("false".to_string())
-        // .arg(1)
-        // .arg("TEST".to_string())
-        // .arg(888)
         Ok(())
     }
 

--- a/crates/findex/src/db_interfaces/redis.rs
+++ b/crates/findex/src/db_interfaces/redis.rs
@@ -4,10 +4,11 @@ use std::{
     fmt::{self, Debug, Display},
     hash::Hash,
     marker::PhantomData,
+    ops::Deref,
     sync::{Arc, Mutex},
 };
 
-use redis::{Commands, Connection, Script, ToRedisArgs};
+use redis::{Commands, Connection, Script};
 
 use crate::db_interfaces::DbInterfaceError;
 use findex::MemoryADT;
@@ -121,8 +122,11 @@ impl Display for RedisMemoryError {
     }
 }
 
-impl<Address: Send + Sync + Hash + Eq + Debug + Clone + ToRedisArgs, const WORD_LENGTH: usize>
-    MemoryADT for RedisBackend<Address, WORD_LENGTH>
+impl<
+        Address: Send + Sync + Hash + Eq + Debug + Clone + Deref<Target = [u8; ADDRESS_LENGTH]>,
+        const ADDRESS_LENGTH: usize,
+        const WORD_LENGTH: usize,
+    > MemoryADT for RedisBackend<Address, WORD_LENGTH>
 {
     type Address = Address;
     type Error = RedisMemoryError;
@@ -133,7 +137,8 @@ impl<Address: Send + Sync + Hash + Eq + Debug + Clone + ToRedisArgs, const WORD_
         addresses: Vec<Address>,
     ) -> Result<Vec<Option<Self::Word>>, Self::Error> {
         let safe_connection = &mut *self.connection.lock().expect(POISONED_LOCK_ERROR_MSG);
-        let refs: Vec<&Address> = addresses.iter().collect::<Vec<&Address>>(); // Redis MGET requires references to the values
+        let refs: Vec<&[u8; ADDRESS_LENGTH]> =
+            addresses.iter().map(|address| address.deref()).collect();
         safe_connection
             .mget::<_, Vec<_>>(&refs)
             .map_err(Self::Error::from)
@@ -149,7 +154,7 @@ impl<Address: Send + Sync + Hash + Eq + Debug + Clone + ToRedisArgs, const WORD_
 
         let mut script_invocation = self.write_script.prepare_invoke();
 
-        script_invocation.arg(guard_address);
+        script_invocation.arg(&*guard_address);
         if let Some(byte_array) = guard_value {
             script_invocation.arg(&byte_array);
         } else {
@@ -157,7 +162,7 @@ impl<Address: Send + Sync + Hash + Eq + Debug + Clone + ToRedisArgs, const WORD_
         }
         script_invocation.arg(bindings.len());
         for (address, word) in bindings {
-            script_invocation.arg(address).arg(&word);
+            script_invocation.arg(&*address).arg(&word);
         }
 
         script_invocation
@@ -169,12 +174,13 @@ impl<Address: Send + Sync + Hash + Eq + Debug + Clone + ToRedisArgs, const WORD_
 #[cfg(test)]
 mod tests {
 
+    use findex::{
+        test_guarded_write_concurrent, test_single_write_and_read, test_wrong_guard, Address,
+    };
     use futures::executor::block_on;
     use serial_test::serial;
-    use tracing::trace;
 
     use super::*;
-    use crate::{db_interfaces::tests::test_backend, logger::log_init, Configuration};
 
     pub fn get_redis_url() -> String {
         if let Ok(var_env) = std::env::var("REDIS_HOST") {
@@ -186,69 +192,54 @@ mod tests {
 
     #[actix_rt::test]
     #[serial]
-    async fn test_read_write() -> Result<(), DbInterfaceError> {
-        // L'idée c'est de vérifier qu'une modification est rejetée si le gard n'est pas le bon.
+    async fn test_db_flush() -> Result<(), DbInterfaceError> {
+        let memory = RedisBackend::<Address<16>, 16>::connect(&get_redis_url())
+            .await
+            .unwrap();
+        let addr = Address::from([1; 16]);
+        let word = [2; 16];
 
-        let memory = RedisBackend::<u8, 1>::connect(&get_redis_url())
+        block_on(memory.guarded_write((addr.clone(), None), vec![(addr.clone(), word)])).unwrap();
+
+        let result = block_on(memory.batch_read(vec![addr.clone()])).unwrap();
+        assert_eq!(result, vec![Some([2; 16])]);
+        memory.clear_indexes().unwrap();
+
+        let result = block_on(memory.batch_read(vec![addr])).unwrap();
+        assert_eq!(result, vec![None]);
+        Ok(())
+    }
+
+    #[actix_rt::test]
+    #[serial]
+    async fn test_rw_seq() -> Result<(), DbInterfaceError> {
+        let memory = RedisBackend::<Address<16>, 16>::connect(&get_redis_url())
             .await
             .unwrap();
         memory.clear_indexes().unwrap();
-
-        assert_eq!(
-            block_on(memory.guarded_write((0, None), vec![(6, [9])])).unwrap(),
-            None
-        );
-
-        assert_eq!(
-            block_on(memory.guarded_write((0, None), vec![(0, [2]), (1, [1]), (2, [1])])).unwrap(),
-            None
-        );
-
-        assert_eq!(
-            block_on(memory.guarded_write((0, None), vec![(0, [4]), (3, [2]), (4, [2])])).unwrap(),
-            Some([2]) // should return Some([2]), indicating that the guard (None) failed
-        );
-
-        assert_eq!(
-            block_on(memory.guarded_write((0, Some([2])), vec![(0, [4]), (3, [3]), (4, [3])]))
-                .unwrap(),
-            Some([2])
-        );
-
-        assert_eq!(
-            vec![Some([1]), Some([1]), Some([3]), Some([3])],
-            block_on(memory.batch_read(vec![1, 2, 3, 4])).unwrap(),
-        );
+        block_on(test_single_write_and_read(&memory, rand::random()));
         Ok(())
     }
 
     #[actix_rt::test]
     #[serial]
-    #[ignore]
-    async fn test_parallel() -> Result<(), DbInterfaceError> {
-        // spawner bcp d'acteurs qui frappent sur la db ensemble
-        // check this - branch epub
-        // Concurrently adding data to instances of the same vector should not introduce data loss.
-        //  pub async fn test_vector_concurrent<
+    async fn test_guard_seq() -> Result<(), DbInterfaceError> {
+        let memory = RedisBackend::<Address<16>, 16>::connect(&get_redis_url())
+            .await
+            .unwrap();
+        memory.clear_indexes().unwrap();
+        block_on(test_wrong_guard(&memory, rand::random()));
         Ok(())
     }
 
-    // TODO legacy test, à revoir
     #[actix_rt::test]
     #[serial]
-    #[ignore]
-    async fn test_redis_backend() {
-        log_init();
-        trace!("Test Redis backend.");
-
-        let url = get_redis_url();
-
-        {
-            let memory_to_flush = RedisBackend::<u8, 1>::connect(url.as_str()).await.unwrap();
-            memory_to_flush.clear_indexes().unwrap();
-        }
-
-        let config: Configuration = Configuration::Redis(url.clone());
-        test_backend(config).await;
+    async fn test_rw_ccr() -> Result<(), DbInterfaceError> {
+        let memory = RedisBackend::<Address<16>, 16>::connect(&get_redis_url())
+            .await
+            .unwrap();
+        memory.clear_indexes().unwrap();
+        block_on(test_guarded_write_concurrent(memory, rand::random()));
+        Ok(())
     }
 }

--- a/crates/findex/src/db_interfaces/tests.rs
+++ b/crates/findex/src/db_interfaces/tests.rs
@@ -156,34 +156,34 @@ async fn insert_users(findex: &InstantiatedFindex, key: &UserKey, label: &Label)
 
 /// Asserts each user can be retrieved using each field it is indexed for.
 async fn find_users(findex: &InstantiatedFindex, key: &UserKey, label: &Label) {
-    // let users = get_users().unwrap();
+    let users = get_users().unwrap();
 
-    // // Assert results are reachable from each indexing keyword.
-    // for (idx, user) in users.iter().enumerate() {
-    //     trace!("Search indexes.");
+    // Assert results are reachable from each indexing keyword.
+    for (idx, user) in users.iter().enumerate() {
+        trace!("Search indexes.");
 
-    //     let res = findex
-    //         .search(
-    //             key,
-    //             label,
-    //             Keywords::from_iter(
-    //                 user.values()
-    //                     .into_iter()
-    //                     .map(|word| Keyword::from(word.as_bytes())),
-    //             ),
-    //             &|_| async move { Ok(false) },
-    //         )
-    //         .await
-    //         .unwrap();
+        let res = findex
+            .search(
+                key,
+                label,
+                Keywords::from_iter(
+                    user.values()
+                        .into_iter()
+                        .map(|word| Keyword::from(word.as_bytes())),
+                ),
+                &|_| async move { Ok(false) },
+            )
+            .await
+            .unwrap();
 
-    //     for word in user.values() {
-    //         let keyword = Keyword::from(word.as_bytes());
-    //         let data = Data::from((idx as i64).to_be_bytes().as_slice());
-    //         assert!(res.contains_key(&keyword));
-    //         let word_res = res.get(&keyword).unwrap();
-    //         assert!(word_res.contains(&data));
-    //     }
-    // }
+        for word in user.values() {
+            let keyword = Keyword::from(word.as_bytes());
+            let data = Data::from((idx as i64).to_be_bytes().as_slice());
+            assert!(res.contains_key(&keyword));
+            let word_res = res.get(&keyword).unwrap();
+            assert!(word_res.contains(&data));
+        }
+    }
 }
 
 /// This test:
@@ -228,39 +228,39 @@ pub async fn test_backend(config: Configuration) {
     find_users(&findex, &new_key, &new_label).await;
 }
 
-pub async fn test_non_regression(_config: Configuration) {
-    // let is_non_regression = true;
-    // let key = get_key(is_non_regression);
-    // let label = get_label(is_non_regression);
+pub async fn test_non_regression(config: Configuration) {
+    let is_non_regression = true;
+    let key = get_key(is_non_regression);
+    let label = get_label(is_non_regression);
 
-    // let mut expected_results: Vec<i64> =
-    //     serde_json::from_str(include_str!("../../datasets/expected_db_uids.json"))
-    //         .map_err(|e| DbInterfaceError::Serialization(e.to_string()))
-    //         .unwrap();
-    // expected_results.sort_unstable();
+    let mut expected_results: Vec<i64> =
+        serde_json::from_str(include_str!("../../datasets/expected_db_uids.json"))
+            .map_err(|e| DbInterfaceError::Serialization(e.to_string()))
+            .unwrap();
+    expected_results.sort_unstable();
 
-    // let findex = InstantiatedFindex::new(config).await.unwrap();
+    let findex = InstantiatedFindex::new(config).await.unwrap();
 
-    // let keyword = Keyword::from("France".as_bytes());
-    // let results = findex
-    //     .search(
-    //         &key,
-    //         &label,
-    //         Keywords::from_iter([keyword.clone()]),
-    //         &|_| async move { Ok(false) },
-    //     )
-    //     .await
-    //     .unwrap();
+    let keyword = Keyword::from("France".as_bytes());
+    let results = findex
+        .search(
+            &key,
+            &label,
+            Keywords::from_iter([keyword.clone()]),
+            &|_| async move { Ok(false) },
+        )
+        .await
+        .unwrap();
 
-    // let mut results = results
-    //     .get(&keyword)
-    //     .unwrap()
-    //     .iter()
-    //     .map(|data| i64::from_be_bytes(data.as_ref().try_into().unwrap()))
-    //     .collect::<Vec<_>>();
-    // results.sort_unstable();
+    let mut results = results
+        .get(&keyword)
+        .unwrap()
+        .iter()
+        .map(|data| i64::from_be_bytes(data.as_ref().try_into().unwrap()))
+        .collect::<Vec<_>>();
+    results.sort_unstable();
 
-    // assert_eq!(results, expected_results);
+    assert_eq!(results, expected_results);
 }
 
 pub async fn test_generate_non_regression_db(config: Configuration) {

--- a/crates/findex/src/db_interfaces/tests.rs
+++ b/crates/findex/src/db_interfaces/tests.rs
@@ -156,34 +156,34 @@ async fn insert_users(findex: &InstantiatedFindex, key: &UserKey, label: &Label)
 
 /// Asserts each user can be retrieved using each field it is indexed for.
 async fn find_users(findex: &InstantiatedFindex, key: &UserKey, label: &Label) {
-    let users = get_users().unwrap();
+    // let users = get_users().unwrap();
 
-    // Assert results are reachable from each indexing keyword.
-    for (idx, user) in users.iter().enumerate() {
-        trace!("Search indexes.");
+    // // Assert results are reachable from each indexing keyword.
+    // for (idx, user) in users.iter().enumerate() {
+    //     trace!("Search indexes.");
 
-        let res = findex
-            .search(
-                key,
-                label,
-                Keywords::from_iter(
-                    user.values()
-                        .into_iter()
-                        .map(|word| Keyword::from(word.as_bytes())),
-                ),
-                &|_| async move { Ok(false) },
-            )
-            .await
-            .unwrap();
+    //     let res = findex
+    //         .search(
+    //             key,
+    //             label,
+    //             Keywords::from_iter(
+    //                 user.values()
+    //                     .into_iter()
+    //                     .map(|word| Keyword::from(word.as_bytes())),
+    //             ),
+    //             &|_| async move { Ok(false) },
+    //         )
+    //         .await
+    //         .unwrap();
 
-        for word in user.values() {
-            let keyword = Keyword::from(word.as_bytes());
-            let data = Data::from((idx as i64).to_be_bytes().as_slice());
-            assert!(res.contains_key(&keyword));
-            let word_res = res.get(&keyword).unwrap();
-            assert!(word_res.contains(&data));
-        }
-    }
+    //     for word in user.values() {
+    //         let keyword = Keyword::from(word.as_bytes());
+    //         let data = Data::from((idx as i64).to_be_bytes().as_slice());
+    //         assert!(res.contains_key(&keyword));
+    //         let word_res = res.get(&keyword).unwrap();
+    //         assert!(word_res.contains(&data));
+    //     }
+    // }
 }
 
 /// This test:
@@ -229,38 +229,38 @@ pub async fn test_backend(config: Configuration) {
 }
 
 pub async fn test_non_regression(config: Configuration) {
-    let is_non_regression = true;
-    let key = get_key(is_non_regression);
-    let label = get_label(is_non_regression);
+    // let is_non_regression = true;
+    // let key = get_key(is_non_regression);
+    // let label = get_label(is_non_regression);
 
-    let mut expected_results: Vec<i64> =
-        serde_json::from_str(include_str!("../../datasets/expected_db_uids.json"))
-            .map_err(|e| DbInterfaceError::Serialization(e.to_string()))
-            .unwrap();
-    expected_results.sort_unstable();
+    // let mut expected_results: Vec<i64> =
+    //     serde_json::from_str(include_str!("../../datasets/expected_db_uids.json"))
+    //         .map_err(|e| DbInterfaceError::Serialization(e.to_string()))
+    //         .unwrap();
+    // expected_results.sort_unstable();
 
-    let findex = InstantiatedFindex::new(config).await.unwrap();
+    // let findex = InstantiatedFindex::new(config).await.unwrap();
 
-    let keyword = Keyword::from("France".as_bytes());
-    let results = findex
-        .search(
-            &key,
-            &label,
-            Keywords::from_iter([keyword.clone()]),
-            &|_| async move { Ok(false) },
-        )
-        .await
-        .unwrap();
+    // let keyword = Keyword::from("France".as_bytes());
+    // let results = findex
+    //     .search(
+    //         &key,
+    //         &label,
+    //         Keywords::from_iter([keyword.clone()]),
+    //         &|_| async move { Ok(false) },
+    //     )
+    //     .await
+    //     .unwrap();
 
-    let mut results = results
-        .get(&keyword)
-        .unwrap()
-        .iter()
-        .map(|data| i64::from_be_bytes(data.as_ref().try_into().unwrap()))
-        .collect::<Vec<_>>();
-    results.sort_unstable();
+    // let mut results = results
+    //     .get(&keyword)
+    //     .unwrap()
+    //     .iter()
+    //     .map(|data| i64::from_be_bytes(data.as_ref().try_into().unwrap()))
+    //     .collect::<Vec<_>>();
+    // results.sort_unstable();
 
-    assert_eq!(results, expected_results);
+    // assert_eq!(results, expected_results);
 }
 
 pub async fn test_generate_non_regression_db(config: Configuration) {

--- a/crates/findex/src/db_interfaces/tests.rs
+++ b/crates/findex/src/db_interfaces/tests.rs
@@ -228,7 +228,7 @@ pub async fn test_backend(config: Configuration) {
     find_users(&findex, &new_key, &new_label).await;
 }
 
-pub async fn test_non_regression(config: Configuration) {
+pub async fn test_non_regression(_config: Configuration) {
     // let is_non_regression = true;
     // let key = get_key(is_non_regression);
     // let label = get_label(is_non_regression);

--- a/crates/findex/src/instantiation/db_config.rs
+++ b/crates/findex/src/instantiation/db_config.rs
@@ -35,7 +35,7 @@ pub enum Configuration {
 
     /// Redis DB interface requests an URL to a valid instance.
     #[cfg(feature = "redis-interface")]
-    Redis(String, String),
+    Redis(String),
 
     /// WASM DB interface requests WASM functions corresponding to the APIs used by
     /// the Entry/Chain tables.

--- a/crates/findex/src/instantiation/findex.rs
+++ b/crates/findex/src/instantiation/findex.rs
@@ -94,15 +94,15 @@ pub enum InstantiatedFindex {
     ),
 }
 /// Temporary enum for Findex migration
-#[deprecated(
-    since = "7.0.0",
-    note = "This enum is temporary and will be removed after migration to new Findex version"
-)]
-#[derive(Debug)]
-pub enum SearchResult {
-    Old(KeywordToDataMap),
-    Recent(HashMap<Keyword, HashSet<Value>>),
-}
+// #[deprecated(
+//     since = "7.0.0",
+//     note = "This enum is temporary and will be removed after migration to new Findex version"
+// )]
+// #[derive(Debug)]
+// pub enum SearchResult {
+//     Old(KeywordToDataMap),
+//     Recent(HashMap<Keyword, HashSet<Value>>),
+// }
 
 impl InstantiatedFindex {
     /// Wrapper around Findex [`new`](Index::new) for static dispatch.
@@ -182,14 +182,13 @@ impl InstantiatedFindex {
     pub async fn search<
         F: Future<Output = Result<bool, String>>,
         Interrupt: Fn(HashMap<Keyword, HashSet<IndexedValue<Keyword, Data>>>) -> F,
-        K: std::iter::Iterator<Item = Keyword>,
     >(
         &self,
         key: &UserKey,
         label: &Label,
-        keywords: K,
+        keywords: Keywords,
         interrupt: &Interrupt,
-    ) -> Result<SearchResult, FindexError<DbInterfaceError>> {
+    ) -> Result<KeywordToDataMap, FindexError<DbInterfaceError>> {
         match self {
             #[cfg(feature = "rest-interface")]
             Self::Rest(findex) => findex.search(key, label, keywords, interrupt).await,
@@ -200,7 +199,9 @@ impl InstantiatedFindex {
             #[cfg(feature = "sqlite-interface")]
             Self::Sqlite(findex) => findex.search(key, label, keywords, interrupt).await,
             #[cfg(feature = "redis-interface")]
-            Self::Redis(findex) => Ok(SearchResult::Recent(findex.search(keywords).await.unwrap())),
+            Self::Redis(findex) => Ok(todo!(
+                "SearchResult::Recent(findex.search(keywords).await.unwrap())"
+            )),
             #[cfg(feature = "wasm")]
             Self::Wasm(findex) => findex.search(key, label, keywords, interrupt).await,
         }
@@ -218,7 +219,7 @@ impl InstantiatedFindex {
             Self::Sqlite(findex) => findex.add(key, label, additions).await,
             #[cfg(feature = "redis-interface")]
             Self::Redis(findex) => {
-                todo!("add me")
+                todo!("TBD")
             }
             #[cfg(feature = "ffi")]
             Self::Ffi(findex) => findex.add(key, label, additions).await,
@@ -242,7 +243,7 @@ impl InstantiatedFindex {
             #[cfg(feature = "sqlite-interface")]
             Self::Sqlite(findex) => findex.delete(key, label, deletions).await,
             #[cfg(feature = "redis-interface")]
-            Self::Redis(findex) => todo!("do me"),
+            Self::Redis(findex) => todo!("TBD"),
             #[cfg(feature = "ffi")]
             Self::Ffi(findex) => findex.delete(key, label, deletions).await,
             #[cfg(feature = "python")]

--- a/crates/findex/src/instantiation/findex.rs
+++ b/crates/findex/src/instantiation/findex.rs
@@ -1,13 +1,24 @@
 use std::{
     collections::{HashMap, HashSet},
+    convert::Infallible,
     future::Future,
 };
 
+use cosmian_crypto_core::RandomFixedSizeCBytes;
 use cosmian_findex::{
     ChainTable, Data, DxEnc, EntryTable, Error as FindexError, Findex, Index, IndexedValue,
     IndexedValueToKeywordsMap, Keyword, KeywordToDataMap, Keywords, Label, UserKey, ENTRY_LENGTH,
     LINK_LENGTH,
 };
+
+use findex::{
+    dummy_decode, dummy_encode, Address, Findex as Findex_v7, IndexADT, Secret, Value,
+    ADDRESS_LENGTH,
+};
+use rand_chacha::ChaChaRng;
+use tracing::error;
+
+const WORD_LENGTH: usize = 16;
 
 #[cfg(feature = "ffi")]
 use crate::db_interfaces::custom::ffi::{FfiChainBackend, FfiEntryBackend};
@@ -16,12 +27,14 @@ use crate::db_interfaces::custom::python::{PythonChainBackend, PythonEntryBacken
 #[cfg(feature = "wasm")]
 use crate::db_interfaces::custom::wasm::{WasmChainBackend, WasmEntryBackend};
 #[cfg(feature = "redis-interface")]
-use crate::db_interfaces::redis::{RedisChainBackend, RedisEntryBackend};
+use crate::db_interfaces::redis::RedisBackend;
 #[cfg(feature = "rest-interface")]
 use crate::db_interfaces::rest::{RestChainBackend, RestEntryBackend, RestParameters};
 #[cfg(feature = "sqlite-interface")]
 use crate::db_interfaces::sqlite::{SqlChainBackend, SqlEntryBackend};
 use crate::{db_interfaces::DbInterfaceError, Configuration};
+#[cfg(feature = "redis-interface")]
+use rand_core::SeedableRng;
 
 /// Wrapper around Findex instantiations used for static dispatch.
 #[derive(Debug)]
@@ -37,10 +50,11 @@ pub enum InstantiatedFindex {
 
     #[cfg(feature = "redis-interface")]
     Redis(
-        Findex<
-            DbInterfaceError,
-            EntryTable<ENTRY_LENGTH, RedisEntryBackend>,
-            ChainTable<LINK_LENGTH, RedisChainBackend>,
+        Findex_v7<
+            WORD_LENGTH,
+            Value,
+            Infallible,
+            RedisBackend<Address<ADDRESS_LENGTH>, WORD_LENGTH>,
         >,
     ),
 
@@ -79,6 +93,16 @@ pub enum InstantiatedFindex {
         >,
     ),
 }
+/// Temporary enum for Findex migration
+#[deprecated(
+    since = "7.0.0",
+    note = "This enum is temporary and will be removed after migration to new Findex version"
+)]
+#[derive(Debug)]
+pub enum SearchResult {
+    Old(KeywordToDataMap),
+    Recent(HashMap<Keyword, HashSet<Value>>),
+}
 
 impl InstantiatedFindex {
     /// Wrapper around Findex [`new`](Index::new) for static dispatch.
@@ -91,9 +115,12 @@ impl InstantiatedFindex {
             )),
 
             #[cfg(feature = "redis-interface")]
-            Configuration::Redis(entry_params, chain_params) => Self::Redis(Findex::new(
-                EntryTable::setup(RedisEntryBackend::connect(&entry_params).await?),
-                ChainTable::setup(RedisChainBackend::connect(&chain_params).await?),
+            Configuration::Redis(entry_params) => Self::Redis(Findex_v7::new(
+                Secret::random(&mut ChaChaRng::from_entropy()),
+                RedisBackend::<Address<ADDRESS_LENGTH>, WORD_LENGTH>::connect(&entry_params)
+                    .await?,
+                dummy_encode::<WORD_LENGTH, _>,
+                dummy_decode,
             )),
 
             #[cfg(feature = "rest-interface")]
@@ -127,14 +154,19 @@ impl InstantiatedFindex {
         Ok(findex)
     }
 
-    /// Wrapper around Findex [`keygen`](Index::keygen) for static dispatch.
-    #[must_use]
+    #[deprecated(
+        since = "7.0.0",
+        note = "keygen is no longer supported in the new Findex version. This is a temporary placeholder until removal."
+    )]
     pub fn keygen(&self) -> UserKey {
         match self {
             #[cfg(feature = "sqlite-interface")]
             Self::Sqlite(findex) => findex.keygen(),
             #[cfg(feature = "redis-interface")]
-            Self::Redis(findex) => findex.keygen(),
+            Self::Redis(findex) => {
+                error!("Keygen is deprecated and not supported in the new Findex version.");
+                UserKey::new(&mut ChaChaRng::from_entropy())
+            }
             #[cfg(feature = "ffi")]
             Self::Ffi(findex) => findex.keygen(),
             #[cfg(feature = "python")]
@@ -150,13 +182,14 @@ impl InstantiatedFindex {
     pub async fn search<
         F: Future<Output = Result<bool, String>>,
         Interrupt: Fn(HashMap<Keyword, HashSet<IndexedValue<Keyword, Data>>>) -> F,
+        K: std::iter::Iterator<Item = Keyword>,
     >(
         &self,
         key: &UserKey,
         label: &Label,
-        keywords: Keywords,
+        keywords: K,
         interrupt: &Interrupt,
-    ) -> Result<KeywordToDataMap, FindexError<DbInterfaceError>> {
+    ) -> Result<SearchResult, FindexError<DbInterfaceError>> {
         match self {
             #[cfg(feature = "rest-interface")]
             Self::Rest(findex) => findex.search(key, label, keywords, interrupt).await,
@@ -167,7 +200,7 @@ impl InstantiatedFindex {
             #[cfg(feature = "sqlite-interface")]
             Self::Sqlite(findex) => findex.search(key, label, keywords, interrupt).await,
             #[cfg(feature = "redis-interface")]
-            Self::Redis(findex) => findex.search(key, label, keywords, interrupt).await,
+            Self::Redis(findex) => Ok(SearchResult::Recent(findex.search(keywords).await.unwrap())),
             #[cfg(feature = "wasm")]
             Self::Wasm(findex) => findex.search(key, label, keywords, interrupt).await,
         }
@@ -184,7 +217,9 @@ impl InstantiatedFindex {
             #[cfg(feature = "sqlite-interface")]
             Self::Sqlite(findex) => findex.add(key, label, additions).await,
             #[cfg(feature = "redis-interface")]
-            Self::Redis(findex) => findex.add(key, label, additions).await,
+            Self::Redis(findex) => {
+                todo!("add me")
+            }
             #[cfg(feature = "ffi")]
             Self::Ffi(findex) => findex.add(key, label, additions).await,
             #[cfg(feature = "python")]
@@ -207,7 +242,7 @@ impl InstantiatedFindex {
             #[cfg(feature = "sqlite-interface")]
             Self::Sqlite(findex) => findex.delete(key, label, deletions).await,
             #[cfg(feature = "redis-interface")]
-            Self::Redis(findex) => findex.delete(key, label, deletions).await,
+            Self::Redis(findex) => todo!("do me"),
             #[cfg(feature = "ffi")]
             Self::Ffi(findex) => findex.delete(key, label, deletions).await,
             #[cfg(feature = "python")]
@@ -219,7 +254,10 @@ impl InstantiatedFindex {
         }
     }
 
-    /// Wrapper around Findex [`compact`](Findex::compact) for static dispatch.
+    #[deprecated(
+        since = "7.0.0",
+        note = "compact is no longer supported in the new Findex version. This is a temporary placeholder until removal."
+    )]
     pub async fn compact<
         F: Future<Output = Result<HashSet<Data>, String>>,
         Filter: Fn(HashSet<Data>) -> F,
@@ -247,17 +285,9 @@ impl InstantiatedFindex {
                     .await
             }
             #[cfg(feature = "redis-interface")]
-            Self::Redis(findex) => {
-                findex
-                    .compact(
-                        old_key,
-                        new_key,
-                        old_label,
-                        new_label,
-                        compacting_rate,
-                        data_filter,
-                    )
-                    .await
+            Self::Redis(_findex) => {
+                error!("This is not supposed to be called on Redis.");
+                Ok(())
             }
             #[cfg(feature = "ffi")]
             Self::Ffi(findex) => {


### PR DESCRIPTION
In replacement of : https://github.com/Cosmian/cloudproof_rust/pull/73

Dependent of findex PR : https://github.com/Cosmian/findex/pull/92

## What's implemented : 
- [x] Instanciate a v7 findex redis interface
- [x] unit tests
- [x] save LUA script in redis cache to avoid sending it over network
- [x] Mutex on connection -> is that necessary ? TB discussed
- [ ]  ~~connection manager instead of "connection"~~ So far and for a reason that I don't get my hands on, using a connection manager causes infnite waiting time when performing an operation. To be checked out ( here is a branch with one commit that uses connection manager : ca3ab1c093915749e83a6d93f0f69236975cc1df)